### PR TITLE
修复高DPI下的控件显示错乱问题

### DIFF
--- a/Source/GrasscutterTools/Forms/FormMain.Designer.cs
+++ b/Source/GrasscutterTools/Forms/FormMain.Designer.cs
@@ -116,13 +116,14 @@ namespace GrasscutterTools.Forms
             // 
             // MenuSpawnEntityFilter
             // 
+            this.MenuSpawnEntityFilter.ImageScalingSize = new System.Drawing.Size(24, 24);
             this.MenuSpawnEntityFilter.Name = "MenuSpawnEntityFilter";
             resources.ApplyResources(this.MenuSpawnEntityFilter, "MenuSpawnEntityFilter");
             // 
             // FormMain
             // 
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
             resources.ApplyResources(this, "$this");
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.NavContainer);
             this.Controls.Add(this.GrpCommand);
             this.KeyPreview = true;

--- a/Source/GrasscutterTools/Forms/FormMain.resx
+++ b/Source/GrasscutterTools/Forms/FormMain.resx
@@ -123,7 +123,10 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="NavContainer.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 12</value>
+    <value>19, 17</value>
+  </data>
+  <data name="NavContainer.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="ListPages.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -138,8 +141,11 @@
   <data name="ListPages.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
+  <data name="ListPages.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
   <data name="ListPages.Size" type="System.Drawing.Size, System.Drawing">
-    <value>150, 275</value>
+    <value>235, 388</value>
   </data>
   <data name="ListPages.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -187,10 +193,13 @@
     <value>610</value>
   </data>
   <data name="NavContainer.Size" type="System.Drawing.Size, System.Drawing">
-    <value>810, 275</value>
+    <value>1273, 388</value>
   </data>
   <data name="NavContainer.SplitterDistance" type="System.Int32, mscorlib">
-    <value>150</value>
+    <value>235</value>
+  </data>
+  <data name="NavContainer.SplitterWidth" type="System.Int32, mscorlib">
+    <value>6</value>
   </data>
   <data name="NavContainer.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -211,10 +220,13 @@
     <value>Top, Left, Right</value>
   </data>
   <data name="CmbCommand.Location" type="System.Drawing.Point, System.Drawing">
-    <value>115, 22</value>
+    <value>181, 31</value>
+  </data>
+  <data name="CmbCommand.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="CmbCommand.Size" type="System.Drawing.Size, System.Drawing">
-    <value>600, 25</value>
+    <value>941, 32</value>
   </data>
   <data name="CmbCommand.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -235,10 +247,13 @@
     <value>NoControl</value>
   </data>
   <data name="BtnCopy.Location" type="System.Drawing.Point, System.Drawing">
-    <value>59, 22</value>
+    <value>93, 31</value>
+  </data>
+  <data name="BtnCopy.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="BtnCopy.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 25</value>
+    <value>79, 35</value>
   </data>
   <data name="BtnCopy.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -265,10 +280,13 @@
     <value>NoControl</value>
   </data>
   <data name="ChkAutoCopy.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 24</value>
+    <value>16, 34</value>
+  </data>
+  <data name="ChkAutoCopy.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="ChkAutoCopy.Size" type="System.Drawing.Size, System.Drawing">
-    <value>51, 21</value>
+    <value>72, 28</value>
   </data>
   <data name="ChkAutoCopy.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -301,10 +319,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblClearFilter.Location" type="System.Drawing.Point, System.Drawing">
-    <value>680, 26</value>
+    <value>1069, 37</value>
+  </data>
+  <data name="LblClearFilter.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblClearFilter.Size" type="System.Drawing.Size, System.Drawing">
-    <value>16, 17</value>
+    <value>22, 24</value>
   </data>
   <data name="LblClearFilter.TabIndex" type="System.Int32, mscorlib">
     <value>24</value>
@@ -334,10 +355,13 @@
     <value>NoControl</value>
   </data>
   <data name="BtnInvokeOpenCommand.Location" type="System.Drawing.Point, System.Drawing">
-    <value>721, 22</value>
+    <value>1133, 31</value>
+  </data>
+  <data name="BtnInvokeOpenCommand.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="BtnInvokeOpenCommand.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 25</value>
+    <value>118, 35</value>
   </data>
   <data name="BtnInvokeOpenCommand.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -358,13 +382,19 @@
     <value>1</value>
   </data>
   <data name="GrpCommand.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 293</value>
+    <value>19, 414</value>
+  </data>
+  <data name="GrpCommand.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="GrpCommand.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>610, 56</value>
+    <value>959, 79</value>
+  </data>
+  <data name="GrpCommand.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="GrpCommand.Size" type="System.Drawing.Size, System.Drawing">
-    <value>810, 56</value>
+    <value>1273, 79</value>
   </data>
   <data name="GrpCommand.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -399,20 +429,17 @@
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>7, 17</value>
-  </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>834, 361</value>
+    <value>1311, 510</value>
   </data>
   <data name="$this.Font" type="System.Drawing.Font, System.Drawing">
     <value>Microsoft YaHei UI, 9pt</value>
   </data>
   <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 4, 3, 4</value>
+    <value>5, 6, 5, 6</value>
   </data>
   <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>850, 400</value>
+    <value>1323, 542</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>

--- a/Source/GrasscutterTools/Forms/FormMain.resx
+++ b/Source/GrasscutterTools/Forms/FormMain.resx
@@ -439,7 +439,7 @@
     <value>5, 6, 5, 6</value>
   </data>
   <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>1323, 542</value>
+    <value>850, 400</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>

--- a/Source/GrasscutterTools/GrasscutterTools.csproj
+++ b/Source/GrasscutterTools/GrasscutterTools.csproj
@@ -352,6 +352,7 @@
     <Compile Include="Utils\ArtifactUtils.cs" />
     <Compile Include="Utils\Common.cs" />
     <Compile Include="Utils\GuiRedirect.cs" />
+    <Compile Include="Utils\HighDPIUtil.cs" />
     <Compile Include="Utils\KeyGo.cs" />
     <Compile Include="Utils\HotKeyItem.cs" />
     <Compile Include="Utils\HttpHelper.cs" />

--- a/Source/GrasscutterTools/Pages/PageAchievement.resx
+++ b/Source/GrasscutterTools/Pages/PageAchievement.resx
@@ -123,14 +123,17 @@
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="ListAchievements.ItemHeight" type="System.Int32, mscorlib">
-    <value>17</value>
+    <value>24</value>
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="ListAchievements.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 51</value>
+    <value>9, 72</value>
+  </data>
+  <data name="ListAchievements.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="ListAchievements.Size" type="System.Drawing.Size, System.Drawing">
-    <value>628, 106</value>
+    <value>985, 148</value>
   </data>
   <data name="ListAchievements.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -160,10 +163,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblClearFilter.Location" type="System.Drawing.Point, System.Drawing">
-    <value>617, 25</value>
+    <value>970, 35</value>
+  </data>
+  <data name="LblClearFilter.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblClearFilter.Size" type="System.Drawing.Size, System.Drawing">
-    <value>16, 17</value>
+    <value>22, 24</value>
   </data>
   <data name="LblClearFilter.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -190,10 +196,13 @@
     <value>Top, Left, Right</value>
   </data>
   <data name="TxtAchievementFilter.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 22</value>
+    <value>9, 31</value>
+  </data>
+  <data name="TxtAchievementFilter.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="TxtAchievementFilter.Size" type="System.Drawing.Size, System.Drawing">
-    <value>628, 23</value>
+    <value>985, 30</value>
   </data>
   <data name="TxtAchievementFilter.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -217,10 +226,13 @@
     <value>True</value>
   </data>
   <data name="LnkRevokeAll.Location" type="System.Drawing.Point, System.Drawing">
-    <value>578, 0</value>
+    <value>908, 0</value>
+  </data>
+  <data name="LnkRevokeAll.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LnkRevokeAll.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 17</value>
+    <value>82, 24</value>
   </data>
   <data name="LnkRevokeAll.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -247,10 +259,13 @@
     <value>True</value>
   </data>
   <data name="LnkGrantAll.Location" type="System.Drawing.Point, System.Drawing">
-    <value>516, 0</value>
+    <value>811, 0</value>
+  </data>
+  <data name="LnkGrantAll.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LnkGrantAll.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 17</value>
+    <value>82, 24</value>
   </data>
   <data name="LnkGrantAll.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -271,10 +286,16 @@
     <value>4</value>
   </data>
   <data name="GrpAchievements.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
+    <value>5, 4</value>
+  </data>
+  <data name="GrpAchievements.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="GrpAchievements.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="GrpAchievements.Size" type="System.Drawing.Size, System.Drawing">
-    <value>640, 167</value>
+    <value>1006, 236</value>
   </data>
   <data name="GrpAchievements.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -301,10 +322,13 @@
     <value>Top, Right</value>
   </data>
   <data name="NUDProgress.Location" type="System.Drawing.Point, System.Drawing">
-    <value>579, 25</value>
+    <value>910, 35</value>
+  </data>
+  <data name="NUDProgress.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="NUDProgress.Size" type="System.Drawing.Size, System.Drawing">
-    <value>55, 23</value>
+    <value>86, 30</value>
   </data>
   <data name="NUDProgress.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -325,10 +349,13 @@
     <value>Top, Right</value>
   </data>
   <data name="BtnProgress.Location" type="System.Drawing.Point, System.Drawing">
-    <value>473, 25</value>
+    <value>743, 35</value>
+  </data>
+  <data name="BtnProgress.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="BtnProgress.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 23</value>
+    <value>157, 32</value>
   </data>
   <data name="BtnProgress.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -349,10 +376,13 @@
     <value>1</value>
   </data>
   <data name="BtnRevoke.Location" type="System.Drawing.Point, System.Drawing">
-    <value>112, 25</value>
+    <value>176, 35</value>
+  </data>
+  <data name="BtnRevoke.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="BtnRevoke.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 23</value>
+    <value>157, 32</value>
   </data>
   <data name="BtnRevoke.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -373,10 +403,13 @@
     <value>2</value>
   </data>
   <data name="BtnGrant.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 25</value>
+    <value>9, 35</value>
+  </data>
+  <data name="BtnGrant.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="BtnGrant.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 23</value>
+    <value>157, 32</value>
   </data>
   <data name="BtnGrant.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -397,10 +430,16 @@
     <value>3</value>
   </data>
   <data name="GrpAchievementCommands.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 176</value>
+    <value>5, 248</value>
+  </data>
+  <data name="GrpAchievementCommands.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="GrpAchievementCommands.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="GrpAchievementCommands.Size" type="System.Drawing.Size, System.Drawing">
-    <value>640, 60</value>
+    <value>1006, 85</value>
   </data>
   <data name="GrpAchievementCommands.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -424,12 +463,15 @@
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>7, 17</value>
+    <value>11, 24</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1015, 337</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PageAchievement</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>GrasscutterTools.Pages.BasePage, GrasscutterTools, Version=1.13.0.0, Culture=neutral, PublicKeyToken=de2b1c089621e923</value>
+    <value>GrasscutterTools.Pages.BasePage, GrasscutterTools, Version=1.15.2.0, Culture=neutral, PublicKeyToken=de2b1c089621e923</value>
   </data>
 </root>

--- a/Source/GrasscutterTools/Pages/PageAvatar.resx
+++ b/Source/GrasscutterTools/Pages/PageAvatar.resx
@@ -130,10 +130,13 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="LnkSetAllConst.Location" type="System.Drawing.Point, System.Drawing">
-    <value>198, 24</value>
+    <value>311, 34</value>
+  </data>
+  <data name="LnkSetAllConst.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LnkSetAllConst.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 17</value>
+    <value>118, 24</value>
   </data>
   <data name="LnkSetAllConst.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -160,10 +163,13 @@
     <value>NoControl</value>
   </data>
   <data name="LnkSetConst.Location" type="System.Drawing.Point, System.Drawing">
-    <value>112, 24</value>
+    <value>176, 34</value>
+  </data>
+  <data name="LnkSetConst.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LnkSetConst.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 17</value>
+    <value>118, 24</value>
   </data>
   <data name="LnkSetConst.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -184,10 +190,13 @@
     <value>1</value>
   </data>
   <data name="NUDSetConstellation.Location" type="System.Drawing.Point, System.Drawing">
-    <value>44, 22</value>
+    <value>69, 31</value>
+  </data>
+  <data name="NUDSetConstellation.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="NUDSetConstellation.Size" type="System.Drawing.Size, System.Drawing">
-    <value>62, 23</value>
+    <value>97, 30</value>
   </data>
   <data name="NUDSetConstellation.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -205,10 +214,16 @@
     <value>2</value>
   </data>
   <data name="GrpSetConstellation.Location" type="System.Drawing.Point, System.Drawing">
-    <value>285, 173</value>
+    <value>448, 244</value>
+  </data>
+  <data name="GrpSetConstellation.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="GrpSetConstellation.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="GrpSetConstellation.Size" type="System.Drawing.Size, System.Drawing">
-    <value>332, 55</value>
+    <value>522, 78</value>
   </data>
   <data name="GrpSetConstellation.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -238,10 +253,13 @@
     <value>NoControl</value>
   </data>
   <data name="BtnUnlockStat.Location" type="System.Drawing.Point, System.Drawing">
-    <value>174, 67</value>
+    <value>273, 95</value>
+  </data>
+  <data name="BtnUnlockStat.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="BtnUnlockStat.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 23</value>
+    <value>196, 32</value>
   </data>
   <data name="BtnUnlockStat.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -268,10 +286,13 @@
     <value>NoControl</value>
   </data>
   <data name="BtnLockStat.Location" type="System.Drawing.Point, System.Drawing">
-    <value>43, 67</value>
+    <value>67, 95</value>
+  </data>
+  <data name="BtnLockStat.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="BtnLockStat.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 23</value>
+    <value>196, 32</value>
   </data>
   <data name="BtnLockStat.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -295,10 +316,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblStatTip.Location" type="System.Drawing.Point, System.Drawing">
-    <value>40, 16</value>
+    <value>63, 23</value>
+  </data>
+  <data name="LblStatTip.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblStatTip.Size" type="System.Drawing.Size, System.Drawing">
-    <value>286, 17</value>
+    <value>449, 24</value>
   </data>
   <data name="LblStatTip.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -325,10 +349,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblStatPercent.Location" type="System.Drawing.Point, System.Drawing">
-    <value>283, 39</value>
+    <value>443, 59</value>
+  </data>
+  <data name="LblStatPercent.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblStatPercent.Size" type="System.Drawing.Size, System.Drawing">
-    <value>19, 17</value>
+    <value>26, 24</value>
   </data>
   <data name="LblStatPercent.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -352,10 +379,13 @@
     <value>3</value>
   </data>
   <data name="NUDStat.Location" type="System.Drawing.Point, System.Drawing">
-    <value>207, 37</value>
+    <value>323, 56</value>
+  </data>
+  <data name="NUDStat.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="NUDStat.Size" type="System.Drawing.Size, System.Drawing">
-    <value>70, 23</value>
+    <value>110, 30</value>
   </data>
   <data name="NUDStat.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -373,10 +403,13 @@
     <value>4</value>
   </data>
   <data name="CmbStat.Location" type="System.Drawing.Point, System.Drawing">
-    <value>43, 36</value>
+    <value>67, 55</value>
+  </data>
+  <data name="CmbStat.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="CmbStat.Size" type="System.Drawing.Size, System.Drawing">
-    <value>158, 25</value>
+    <value>246, 32</value>
   </data>
   <data name="CmbStat.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -394,10 +427,16 @@
     <value>5</value>
   </data>
   <data name="GrpSetStats.Location" type="System.Drawing.Point, System.Drawing">
-    <value>285, 10</value>
+    <value>448, 14</value>
+  </data>
+  <data name="GrpSetStats.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="GrpSetStats.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="GrpSetStats.Size" type="System.Drawing.Size, System.Drawing">
-    <value>332, 96</value>
+    <value>522, 136</value>
   </data>
   <data name="GrpSetStats.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -420,6 +459,96 @@
   <data name="GrpTalentLevel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>None</value>
   </data>
+  <data name="&gt;&gt;LnkTalentAll.Name" xml:space="preserve">
+    <value>LnkTalentAll</value>
+  </data>
+  <data name="&gt;&gt;LnkTalentAll.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;LnkTalentAll.Parent" xml:space="preserve">
+    <value>GrpTalentLevel</value>
+  </data>
+  <data name="&gt;&gt;LnkTalentAll.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;LnkTalentE.Name" xml:space="preserve">
+    <value>LnkTalentE</value>
+  </data>
+  <data name="&gt;&gt;LnkTalentE.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;LnkTalentE.Parent" xml:space="preserve">
+    <value>GrpTalentLevel</value>
+  </data>
+  <data name="&gt;&gt;LnkTalentE.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;LnkTalentQ.Name" xml:space="preserve">
+    <value>LnkTalentQ</value>
+  </data>
+  <data name="&gt;&gt;LnkTalentQ.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;LnkTalentQ.Parent" xml:space="preserve">
+    <value>GrpTalentLevel</value>
+  </data>
+  <data name="&gt;&gt;LnkTalentQ.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;LnkTalentNormalATK.Name" xml:space="preserve">
+    <value>LnkTalentNormalATK</value>
+  </data>
+  <data name="&gt;&gt;LnkTalentNormalATK.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;LnkTalentNormalATK.Parent" xml:space="preserve">
+    <value>GrpTalentLevel</value>
+  </data>
+  <data name="&gt;&gt;LnkTalentNormalATK.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;NUDTalentLevel.Name" xml:space="preserve">
+    <value>NUDTalentLevel</value>
+  </data>
+  <data name="&gt;&gt;NUDTalentLevel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;NUDTalentLevel.Parent" xml:space="preserve">
+    <value>GrpTalentLevel</value>
+  </data>
+  <data name="&gt;&gt;NUDTalentLevel.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="GrpTalentLevel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>448, 158</value>
+  </data>
+  <data name="GrpTalentLevel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="GrpTalentLevel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="GrpTalentLevel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>522, 78</value>
+  </data>
+  <data name="GrpTalentLevel.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="GrpTalentLevel.Text" xml:space="preserve">
+    <value>技能等级</value>
+  </data>
+  <data name="&gt;&gt;GrpTalentLevel.Name" xml:space="preserve">
+    <value>GrpTalentLevel</value>
+  </data>
+  <data name="&gt;&gt;GrpTalentLevel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;GrpTalentLevel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;GrpTalentLevel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
   <data name="LnkTalentAll.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -427,10 +556,13 @@
     <value>NoControl</value>
   </data>
   <data name="LnkTalentAll.Location" type="System.Drawing.Point, System.Drawing">
-    <value>112, 24</value>
+    <value>176, 34</value>
+  </data>
+  <data name="LnkTalentAll.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LnkTalentAll.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 17</value>
+    <value>46, 24</value>
   </data>
   <data name="LnkTalentAll.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -457,10 +589,13 @@
     <value>NoControl</value>
   </data>
   <data name="LnkTalentE.Location" type="System.Drawing.Point, System.Drawing">
-    <value>260, 24</value>
+    <value>409, 34</value>
+  </data>
+  <data name="LnkTalentE.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LnkTalentE.Size" type="System.Drawing.Size, System.Drawing">
-    <value>39, 17</value>
+    <value>56, 24</value>
   </data>
   <data name="LnkTalentE.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -487,10 +622,13 @@
     <value>NoControl</value>
   </data>
   <data name="LnkTalentQ.Location" type="System.Drawing.Point, System.Drawing">
-    <value>212, 24</value>
+    <value>333, 34</value>
+  </data>
+  <data name="LnkTalentQ.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LnkTalentQ.Size" type="System.Drawing.Size, System.Drawing">
-    <value>42, 17</value>
+    <value>61, 24</value>
   </data>
   <data name="LnkTalentQ.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -517,10 +655,13 @@
     <value>NoControl</value>
   </data>
   <data name="LnkTalentNormalATK.Location" type="System.Drawing.Point, System.Drawing">
-    <value>150, 24</value>
+    <value>236, 34</value>
+  </data>
+  <data name="LnkTalentNormalATK.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LnkTalentNormalATK.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 17</value>
+    <value>82, 24</value>
   </data>
   <data name="LnkTalentNormalATK.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -541,10 +682,13 @@
     <value>3</value>
   </data>
   <data name="NUDTalentLevel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>44, 22</value>
+    <value>69, 31</value>
+  </data>
+  <data name="NUDTalentLevel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="NUDTalentLevel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>62, 23</value>
+    <value>97, 30</value>
   </data>
   <data name="NUDTalentLevel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -561,32 +705,182 @@
   <data name="&gt;&gt;NUDTalentLevel.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="GrpTalentLevel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>285, 112</value>
-  </data>
-  <data name="GrpTalentLevel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>332, 55</value>
-  </data>
-  <data name="GrpTalentLevel.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="GrpTalentLevel.Text" xml:space="preserve">
-    <value>技能等级</value>
-  </data>
-  <data name="&gt;&gt;GrpTalentLevel.Name" xml:space="preserve">
-    <value>GrpTalentLevel</value>
-  </data>
-  <data name="&gt;&gt;GrpTalentLevel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;GrpTalentLevel.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;GrpTalentLevel.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="GrpGiveAvatar.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>None</value>
+  </data>
+  <data name="&gt;&gt;CmbSwitchElement.Name" xml:space="preserve">
+    <value>CmbSwitchElement</value>
+  </data>
+  <data name="&gt;&gt;CmbSwitchElement.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CmbSwitchElement.Parent" xml:space="preserve">
+    <value>GrpGiveAvatar</value>
+  </data>
+  <data name="&gt;&gt;CmbSwitchElement.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;LnkSwitchElement.Name" xml:space="preserve">
+    <value>LnkSwitchElement</value>
+  </data>
+  <data name="&gt;&gt;LnkSwitchElement.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;LnkSwitchElement.Parent" xml:space="preserve">
+    <value>GrpGiveAvatar</value>
+  </data>
+  <data name="&gt;&gt;LnkSwitchElement.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;CmbAvatar.Name" xml:space="preserve">
+    <value>CmbAvatar</value>
+  </data>
+  <data name="&gt;&gt;CmbAvatar.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CmbAvatar.Parent" xml:space="preserve">
+    <value>GrpGiveAvatar</value>
+  </data>
+  <data name="&gt;&gt;CmbAvatar.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;LblAvatarSkillLevelTip.Name" xml:space="preserve">
+    <value>LblAvatarSkillLevelTip</value>
+  </data>
+  <data name="&gt;&gt;LblAvatarSkillLevelTip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;LblAvatarSkillLevelTip.Parent" xml:space="preserve">
+    <value>GrpGiveAvatar</value>
+  </data>
+  <data name="&gt;&gt;LblAvatarSkillLevelTip.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;NUDAvatarLevel.Name" xml:space="preserve">
+    <value>NUDAvatarLevel</value>
+  </data>
+  <data name="&gt;&gt;NUDAvatarLevel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;NUDAvatarLevel.Parent" xml:space="preserve">
+    <value>GrpGiveAvatar</value>
+  </data>
+  <data name="&gt;&gt;NUDAvatarLevel.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;BtnGiveAllChar.Name" xml:space="preserve">
+    <value>BtnGiveAllChar</value>
+  </data>
+  <data name="&gt;&gt;BtnGiveAllChar.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;BtnGiveAllChar.Parent" xml:space="preserve">
+    <value>GrpGiveAvatar</value>
+  </data>
+  <data name="&gt;&gt;BtnGiveAllChar.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;LblAvatarLevel.Name" xml:space="preserve">
+    <value>LblAvatarLevel</value>
+  </data>
+  <data name="&gt;&gt;LblAvatarLevel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;LblAvatarLevel.Parent" xml:space="preserve">
+    <value>GrpGiveAvatar</value>
+  </data>
+  <data name="&gt;&gt;LblAvatarLevel.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;LblAvatarSkillLevelLabel.Name" xml:space="preserve">
+    <value>LblAvatarSkillLevelLabel</value>
+  </data>
+  <data name="&gt;&gt;LblAvatarSkillLevelLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;LblAvatarSkillLevelLabel.Parent" xml:space="preserve">
+    <value>GrpGiveAvatar</value>
+  </data>
+  <data name="&gt;&gt;LblAvatarSkillLevelLabel.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;LblAvatar.Name" xml:space="preserve">
+    <value>LblAvatar</value>
+  </data>
+  <data name="&gt;&gt;LblAvatar.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;LblAvatar.Parent" xml:space="preserve">
+    <value>GrpGiveAvatar</value>
+  </data>
+  <data name="&gt;&gt;LblAvatar.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;LblAvatarConstellation.Name" xml:space="preserve">
+    <value>LblAvatarConstellation</value>
+  </data>
+  <data name="&gt;&gt;LblAvatarConstellation.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;LblAvatarConstellation.Parent" xml:space="preserve">
+    <value>GrpGiveAvatar</value>
+  </data>
+  <data name="&gt;&gt;LblAvatarConstellation.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;NUDAvatarConstellation.Name" xml:space="preserve">
+    <value>NUDAvatarConstellation</value>
+  </data>
+  <data name="&gt;&gt;NUDAvatarConstellation.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;NUDAvatarConstellation.Parent" xml:space="preserve">
+    <value>GrpGiveAvatar</value>
+  </data>
+  <data name="&gt;&gt;NUDAvatarConstellation.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;NUDAvatarSkillLevel.Name" xml:space="preserve">
+    <value>NUDAvatarSkillLevel</value>
+  </data>
+  <data name="&gt;&gt;NUDAvatarSkillLevel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;NUDAvatarSkillLevel.Parent" xml:space="preserve">
+    <value>GrpGiveAvatar</value>
+  </data>
+  <data name="&gt;&gt;NUDAvatarSkillLevel.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="GrpGiveAvatar.Location" type="System.Drawing.Point, System.Drawing">
+    <value>46, 14</value>
+  </data>
+  <data name="GrpGiveAvatar.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="GrpGiveAvatar.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="GrpGiveAvatar.Size" type="System.Drawing.Size, System.Drawing">
+    <value>393, 308</value>
+  </data>
+  <data name="GrpGiveAvatar.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="GrpGiveAvatar.Text" xml:space="preserve">
+    <value>获取角色</value>
+  </data>
+  <data name="&gt;&gt;GrpGiveAvatar.Name" xml:space="preserve">
+    <value>GrpGiveAvatar</value>
+  </data>
+  <data name="&gt;&gt;GrpGiveAvatar.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;GrpGiveAvatar.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;GrpGiveAvatar.ZOrder" xml:space="preserve">
+    <value>3</value>
   </data>
   <data name="CmbSwitchElement.Items" xml:space="preserve">
     <value>无</value>
@@ -613,10 +907,13 @@
     <value>草</value>
   </data>
   <data name="CmbSwitchElement.Location" type="System.Drawing.Point, System.Drawing">
-    <value>112, 187</value>
+    <value>176, 264</value>
+  </data>
+  <data name="CmbSwitchElement.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="CmbSwitchElement.Size" type="System.Drawing.Size, System.Drawing">
-    <value>87, 25</value>
+    <value>134, 32</value>
   </data>
   <data name="CmbSwitchElement.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -640,10 +937,13 @@
     <value>NoControl</value>
   </data>
   <data name="LnkSwitchElement.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 191</value>
+    <value>25, 270</value>
+  </data>
+  <data name="LnkSwitchElement.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LnkSwitchElement.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 17</value>
+    <value>118, 24</value>
   </data>
   <data name="LnkSwitchElement.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -664,10 +964,13 @@
     <value>1</value>
   </data>
   <data name="CmbAvatar.Location" type="System.Drawing.Point, System.Drawing">
-    <value>89, 22</value>
+    <value>140, 31</value>
+  </data>
+  <data name="CmbAvatar.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="CmbAvatar.Size" type="System.Drawing.Size, System.Drawing">
-    <value>110, 25</value>
+    <value>171, 32</value>
   </data>
   <data name="CmbAvatar.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -691,10 +994,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblAvatarSkillLevelTip.Location" type="System.Drawing.Point, System.Drawing">
-    <value>201, 113</value>
+    <value>316, 160</value>
+  </data>
+  <data name="LblAvatarSkillLevelTip.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblAvatarSkillLevelTip.Size" type="System.Drawing.Size, System.Drawing">
-    <value>46, 17</value>
+    <value>68, 24</value>
   </data>
   <data name="LblAvatarSkillLevelTip.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -715,10 +1021,13 @@
     <value>3</value>
   </data>
   <data name="NUDAvatarLevel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>89, 53</value>
+    <value>140, 75</value>
+  </data>
+  <data name="NUDAvatarLevel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="NUDAvatarLevel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>110, 23</value>
+    <value>173, 30</value>
   </data>
   <data name="NUDAvatarLevel.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -742,10 +1051,13 @@
     <value>NoControl</value>
   </data>
   <data name="BtnGiveAllChar.Location" type="System.Drawing.Point, System.Drawing">
-    <value>49, 140</value>
+    <value>77, 198</value>
+  </data>
+  <data name="BtnGiveAllChar.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="BtnGiveAllChar.Size" type="System.Drawing.Size, System.Drawing">
-    <value>150, 30</value>
+    <value>236, 42</value>
   </data>
   <data name="BtnGiveAllChar.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -772,10 +1084,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblAvatarLevel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>27, 55</value>
+    <value>42, 78</value>
+  </data>
+  <data name="LblAvatarLevel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblAvatarLevel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 17</value>
+    <value>46, 24</value>
   </data>
   <data name="LblAvatarLevel.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -802,10 +1117,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblAvatarSkillLevelLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>27, 113</value>
+    <value>42, 160</value>
+  </data>
+  <data name="LblAvatarSkillLevelLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblAvatarSkillLevelLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 17</value>
+    <value>82, 24</value>
   </data>
   <data name="LblAvatarSkillLevelLabel.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -832,10 +1150,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblAvatar.Location" type="System.Drawing.Point, System.Drawing">
-    <value>27, 25</value>
+    <value>42, 35</value>
+  </data>
+  <data name="LblAvatar.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblAvatar.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 17</value>
+    <value>46, 24</value>
   </data>
   <data name="LblAvatar.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -862,10 +1183,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblAvatarConstellation.Location" type="System.Drawing.Point, System.Drawing">
-    <value>27, 84</value>
+    <value>42, 119</value>
+  </data>
+  <data name="LblAvatarConstellation.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblAvatarConstellation.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 17</value>
+    <value>46, 24</value>
   </data>
   <data name="LblAvatarConstellation.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -886,10 +1210,13 @@
     <value>9</value>
   </data>
   <data name="NUDAvatarConstellation.Location" type="System.Drawing.Point, System.Drawing">
-    <value>89, 82</value>
+    <value>140, 116</value>
+  </data>
+  <data name="NUDAvatarConstellation.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="NUDAvatarConstellation.Size" type="System.Drawing.Size, System.Drawing">
-    <value>110, 23</value>
+    <value>173, 30</value>
   </data>
   <data name="NUDAvatarConstellation.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -907,10 +1234,13 @@
     <value>10</value>
   </data>
   <data name="NUDAvatarSkillLevel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>89, 111</value>
+    <value>140, 157</value>
+  </data>
+  <data name="NUDAvatarSkillLevel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="NUDAvatarSkillLevel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>110, 23</value>
+    <value>173, 30</value>
   </data>
   <data name="NUDAvatarSkillLevel.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -927,40 +1257,19 @@
   <data name="&gt;&gt;NUDAvatarSkillLevel.ZOrder" xml:space="preserve">
     <value>11</value>
   </data>
-  <data name="GrpGiveAvatar.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 10</value>
-  </data>
-  <data name="GrpGiveAvatar.Size" type="System.Drawing.Size, System.Drawing">
-    <value>250, 218</value>
-  </data>
-  <data name="GrpGiveAvatar.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="GrpGiveAvatar.Text" xml:space="preserve">
-    <value>获取角色</value>
-  </data>
-  <data name="&gt;&gt;GrpGiveAvatar.Name" xml:space="preserve">
-    <value>GrpGiveAvatar</value>
-  </data>
-  <data name="&gt;&gt;GrpGiveAvatar.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;GrpGiveAvatar.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;GrpGiveAvatar.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>7, 17</value>
+    <value>11, 24</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1015, 337</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PageAvatar</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>GrasscutterTools.Pages.BasePage, GrasscutterTools, Version=1.7.4.0, Culture=neutral, PublicKeyToken=de2b1c089621e923</value>
+    <value>GrasscutterTools.Pages.BasePage, GrasscutterTools, Version=1.15.2.0, Culture=neutral, PublicKeyToken=de2b1c089621e923</value>
   </data>
 </root>

--- a/Source/GrasscutterTools/Pages/PageGiveArtifact.resx
+++ b/Source/GrasscutterTools/Pages/PageGiveArtifact.resx
@@ -130,10 +130,13 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="LnkCharacterBuilder.Location" type="System.Drawing.Point, System.Drawing">
-    <value>534, 214</value>
+    <value>839, 302</value>
+  </data>
+  <data name="LnkCharacterBuilder.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LnkCharacterBuilder.Size" type="System.Drawing.Size, System.Drawing">
-    <value>109, 17</value>
+    <value>159, 24</value>
   </data>
   <data name="LnkCharacterBuilder.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -163,10 +166,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblArtifactLevelTip.Location" type="System.Drawing.Point, System.Drawing">
-    <value>218, 37</value>
+    <value>343, 52</value>
+  </data>
+  <data name="LblArtifactLevelTip.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblArtifactLevelTip.Size" type="System.Drawing.Size, System.Drawing">
-    <value>42, 17</value>
+    <value>63, 24</value>
   </data>
   <data name="LblArtifactLevelTip.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -193,10 +199,13 @@
     <value>NoControl</value>
   </data>
   <data name="BtnAddSubAttr.Location" type="System.Drawing.Point, System.Drawing">
-    <value>460, 125</value>
+    <value>723, 176</value>
+  </data>
+  <data name="BtnAddSubAttr.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="BtnAddSubAttr.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
+    <value>118, 32</value>
   </data>
   <data name="BtnAddSubAttr.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -226,10 +235,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblArtifactName.Location" type="System.Drawing.Point, System.Drawing">
-    <value>457, 7</value>
+    <value>718, 10</value>
+  </data>
+  <data name="LblArtifactName.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblArtifactName.Size" type="System.Drawing.Size, System.Drawing">
-    <value>0, 17</value>
+    <value>0, 24</value>
   </data>
   <data name="LblArtifactName.TabIndex" type="System.Int32, mscorlib">
     <value>24</value>
@@ -256,10 +268,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblArtifactPart.Location" type="System.Drawing.Point, System.Drawing">
-    <value>293, 7</value>
+    <value>460, 10</value>
+  </data>
+  <data name="LblArtifactPart.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblArtifactPart.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 17</value>
+    <value>46, 24</value>
   </data>
   <data name="LblArtifactPart.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -283,10 +298,13 @@
     <value>Top</value>
   </data>
   <data name="CmbArtifactPart.Location" type="System.Drawing.Point, System.Drawing">
-    <value>331, 4</value>
+    <value>520, 6</value>
+  </data>
+  <data name="CmbArtifactPart.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="CmbArtifactPart.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 25</value>
+    <value>186, 32</value>
   </data>
   <data name="CmbArtifactPart.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -307,10 +325,13 @@
     <value>Top</value>
   </data>
   <data name="CmbArtifactSet.Location" type="System.Drawing.Point, System.Drawing">
-    <value>162, 4</value>
+    <value>255, 6</value>
+  </data>
+  <data name="CmbArtifactSet.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="CmbArtifactSet.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 25</value>
+    <value>194, 32</value>
   </data>
   <data name="CmbArtifactSet.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -337,10 +358,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblArtifactSet.Location" type="System.Drawing.Point, System.Drawing">
-    <value>124, 7</value>
+    <value>195, 10</value>
+  </data>
+  <data name="LblArtifactSet.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblArtifactSet.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 17</value>
+    <value>46, 24</value>
   </data>
   <data name="LblArtifactSet.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -364,10 +388,13 @@
     <value>Top</value>
   </data>
   <data name="NUDSubAttributionTimes.Location" type="System.Drawing.Point, System.Drawing">
-    <value>460, 96</value>
+    <value>723, 136</value>
+  </data>
+  <data name="NUDSubAttributionTimes.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="NUDSubAttributionTimes.Size" type="System.Drawing.Size, System.Drawing">
-    <value>51, 23</value>
+    <value>80, 30</value>
   </data>
   <data name="NUDSubAttributionTimes.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -388,10 +415,13 @@
     <value>Top</value>
   </data>
   <data name="CmbSubAttributionValue.Location" type="System.Drawing.Point, System.Drawing">
-    <value>331, 94</value>
+    <value>520, 133</value>
+  </data>
+  <data name="CmbSubAttributionValue.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="CmbSubAttributionValue.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 25</value>
+    <value>186, 32</value>
   </data>
   <data name="CmbSubAttributionValue.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -412,10 +442,13 @@
     <value>Top</value>
   </data>
   <data name="CmbSubAttribution.Location" type="System.Drawing.Point, System.Drawing">
-    <value>162, 95</value>
+    <value>255, 134</value>
+  </data>
+  <data name="CmbSubAttribution.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="CmbSubAttribution.Size" type="System.Drawing.Size, System.Drawing">
-    <value>163, 25</value>
+    <value>254, 32</value>
   </data>
   <data name="CmbSubAttribution.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -442,10 +475,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblClearSubAttrCheckedList.Location" type="System.Drawing.Point, System.Drawing">
-    <value>457, 214</value>
+    <value>718, 302</value>
+  </data>
+  <data name="LblClearSubAttrCheckedList.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblClearSubAttrCheckedList.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 17</value>
+    <value>63, 24</value>
   </data>
   <data name="LblClearSubAttrCheckedList.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -469,13 +505,16 @@
     <value>Top, Bottom</value>
   </data>
   <data name="ListSubAttributionChecked.ItemHeight" type="System.Int32, mscorlib">
-    <value>17</value>
+    <value>24</value>
   </data>
   <data name="ListSubAttributionChecked.Location" type="System.Drawing.Point, System.Drawing">
-    <value>162, 125</value>
+    <value>255, 176</value>
+  </data>
+  <data name="ListSubAttributionChecked.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="ListSubAttributionChecked.Size" type="System.Drawing.Size, System.Drawing">
-    <value>289, 106</value>
+    <value>452, 148</value>
   </data>
   <data name="ListSubAttributionChecked.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -502,10 +541,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblArtifactLevel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>124, 37</value>
+    <value>195, 52</value>
+  </data>
+  <data name="LblArtifactLevel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblArtifactLevel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 17</value>
+    <value>46, 24</value>
   </data>
   <data name="LblArtifactLevel.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -535,10 +577,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblSubAttribution.Location" type="System.Drawing.Point, System.Drawing">
-    <value>112, 98</value>
+    <value>176, 138</value>
+  </data>
+  <data name="LblSubAttribution.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblSubAttribution.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 17</value>
+    <value>64, 24</value>
   </data>
   <data name="LblSubAttribution.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -562,10 +607,13 @@
     <value>Top</value>
   </data>
   <data name="CmbMainAttribution.Location" type="System.Drawing.Point, System.Drawing">
-    <value>162, 64</value>
+    <value>255, 90</value>
+  </data>
+  <data name="CmbMainAttribution.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="CmbMainAttribution.Size" type="System.Drawing.Size, System.Drawing">
-    <value>289, 25</value>
+    <value>452, 32</value>
   </data>
   <data name="CmbMainAttribution.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -592,10 +640,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblMainAttribution.Location" type="System.Drawing.Point, System.Drawing">
-    <value>112, 67</value>
+    <value>176, 95</value>
+  </data>
+  <data name="LblMainAttribution.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblMainAttribution.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 17</value>
+    <value>64, 24</value>
   </data>
   <data name="LblMainAttribution.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -619,10 +670,13 @@
     <value>Top</value>
   </data>
   <data name="NUDArtifactLevel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>162, 35</value>
+    <value>255, 49</value>
+  </data>
+  <data name="NUDArtifactLevel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="NUDArtifactLevel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 23</value>
+    <value>79, 30</value>
   </data>
   <data name="NUDArtifactLevel.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -649,10 +703,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblArtifactStars.Location" type="System.Drawing.Point, System.Drawing">
-    <value>348, 37</value>
+    <value>547, 52</value>
+  </data>
+  <data name="LblArtifactStars.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblArtifactStars.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 17</value>
+    <value>46, 24</value>
   </data>
   <data name="LblArtifactStars.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -676,10 +733,13 @@
     <value>Top</value>
   </data>
   <data name="NUDArtifactStars.Location" type="System.Drawing.Point, System.Drawing">
-    <value>386, 35</value>
+    <value>607, 49</value>
+  </data>
+  <data name="NUDArtifactStars.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="NUDArtifactStars.Size" type="System.Drawing.Size, System.Drawing">
-    <value>65, 23</value>
+    <value>102, 30</value>
   </data>
   <data name="NUDArtifactStars.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -700,12 +760,15 @@
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>7, 17</value>
+    <value>11, 24</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1015, 337</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PageGiveArtifact</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>GrasscutterTools.Pages.BasePage, GrasscutterTools, Version=1.9.0.0, Culture=neutral, PublicKeyToken=de2b1c089621e923</value>
+    <value>GrasscutterTools.Pages.BasePage, GrasscutterTools, Version=1.15.2.0, Culture=neutral, PublicKeyToken=de2b1c089621e923</value>
   </data>
 </root>

--- a/Source/GrasscutterTools/Pages/PageGiveItem.Designer.cs
+++ b/Source/GrasscutterTools/Pages/PageGiveItem.Designer.cs
@@ -172,6 +172,7 @@
             // 
             // MenuItemFilter
             // 
+            this.MenuItemFilter.ImageScalingSize = new System.Drawing.Size(24, 24);
             this.MenuItemFilter.Name = "MenuSpawnEntityFilter";
             resources.ApplyResources(this.MenuItemFilter, "MenuItemFilter");
             // 

--- a/Source/GrasscutterTools/Pages/PageGiveItem.resx
+++ b/Source/GrasscutterTools/Pages/PageGiveItem.resx
@@ -130,10 +130,13 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="LblClearGiveItemLogs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>262, 187</value>
+    <value>412, 264</value>
+  </data>
+  <data name="LblClearGiveItemLogs.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblClearGiveItemLogs.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 17</value>
+    <value>63, 24</value>
   </data>
   <data name="LblClearGiveItemLogs.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -157,10 +160,13 @@
     <value>NoControl</value>
   </data>
   <data name="BtnSaveGiveItemLog.Location" type="System.Drawing.Point, System.Drawing">
-    <value>265, 48</value>
+    <value>416, 68</value>
+  </data>
+  <data name="BtnSaveGiveItemLog.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="BtnSaveGiveItemLog.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
+    <value>118, 32</value>
   </data>
   <data name="BtnSaveGiveItemLog.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -187,10 +193,13 @@
     <value>NoControl</value>
   </data>
   <data name="BtnRemoveGiveItemLog.Location" type="System.Drawing.Point, System.Drawing">
-    <value>265, 77</value>
+    <value>416, 109</value>
+  </data>
+  <data name="BtnRemoveGiveItemLog.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="BtnRemoveGiveItemLog.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
+    <value>118, 32</value>
   </data>
   <data name="BtnRemoveGiveItemLog.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -213,21 +222,6 @@
   <data name="GrpGiveItemRecord.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Bottom, Left</value>
   </data>
-  <data name="ListGiveItemLogs.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="ListGiveItemLogs.ItemHeight" type="System.Int32, mscorlib">
-    <value>17</value>
-  </data>
-  <data name="ListGiveItemLogs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 19</value>
-  </data>
-  <data name="ListGiveItemLogs.Size" type="System.Drawing.Size, System.Drawing">
-    <value>243, 145</value>
-  </data>
-  <data name="ListGiveItemLogs.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
   <data name="&gt;&gt;ListGiveItemLogs.Name" xml:space="preserve">
     <value>ListGiveItemLogs</value>
   </data>
@@ -241,10 +235,16 @@
     <value>0</value>
   </data>
   <data name="GrpGiveItemRecord.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 45</value>
+    <value>16, 64</value>
+  </data>
+  <data name="GrpGiveItemRecord.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="GrpGiveItemRecord.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="GrpGiveItemRecord.Size" type="System.Drawing.Size, System.Drawing">
-    <value>249, 167</value>
+    <value>391, 236</value>
   </data>
   <data name="GrpGiveItemRecord.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -264,6 +264,36 @@
   <data name="&gt;&gt;GrpGiveItemRecord.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
+  <data name="ListGiveItemLogs.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="ListGiveItemLogs.ItemHeight" type="System.Int32, mscorlib">
+    <value>24</value>
+  </data>
+  <data name="ListGiveItemLogs.Location" type="System.Drawing.Point, System.Drawing">
+    <value>5, 27</value>
+  </data>
+  <data name="ListGiveItemLogs.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="ListGiveItemLogs.Size" type="System.Drawing.Size, System.Drawing">
+    <value>381, 205</value>
+  </data>
+  <data name="ListGiveItemLogs.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;ListGiveItemLogs.Name" xml:space="preserve">
+    <value>ListGiveItemLogs</value>
+  </data>
+  <data name="&gt;&gt;ListGiveItemLogs.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ListGiveItemLogs.Parent" xml:space="preserve">
+    <value>GrpGiveItemRecord</value>
+  </data>
+  <data name="&gt;&gt;ListGiveItemLogs.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="ChkDrop.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
   </data>
@@ -274,10 +304,13 @@
     <value>NoControl</value>
   </data>
   <data name="ChkDrop.Location" type="System.Drawing.Point, System.Drawing">
-    <value>256, 214</value>
+    <value>402, 304</value>
+  </data>
+  <data name="ChkDrop.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="ChkDrop.Size" type="System.Drawing.Size, System.Drawing">
-    <value>51, 21</value>
+    <value>72, 28</value>
   </data>
   <data name="ChkDrop.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -301,10 +334,13 @@
     <value>Top, Left, Right</value>
   </data>
   <data name="TxtGameItemFilter.Location" type="System.Drawing.Point, System.Drawing">
-    <value>498, 3</value>
+    <value>783, 4</value>
+  </data>
+  <data name="TxtGameItemFilter.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="TxtGameItemFilter.Size" type="System.Drawing.Size, System.Drawing">
-    <value>145, 23</value>
+    <value>226, 30</value>
   </data>
   <data name="TxtGameItemFilter.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -325,13 +361,16 @@
     <value>Top, Bottom, Left, Right</value>
   </data>
   <data name="ListGameItems.ItemHeight" type="System.Int32, mscorlib">
-    <value>17</value>
+    <value>24</value>
   </data>
   <data name="ListGameItems.Location" type="System.Drawing.Point, System.Drawing">
-    <value>343, 29</value>
+    <value>539, 41</value>
+  </data>
+  <data name="ListGameItems.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="ListGameItems.Size" type="System.Drawing.Size, System.Drawing">
-    <value>300, 208</value>
+    <value>469, 292</value>
   </data>
   <data name="ListGameItems.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -358,10 +397,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblGameItemAmount.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 215</value>
+    <value>11, 304</value>
+  </data>
+  <data name="LblGameItemAmount.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblGameItemAmount.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 17</value>
+    <value>46, 24</value>
   </data>
   <data name="LblGameItemAmount.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -391,10 +433,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblGameItemLevel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>151, 215</value>
+    <value>237, 304</value>
+  </data>
+  <data name="LblGameItemLevel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblGameItemLevel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 17</value>
+    <value>46, 24</value>
   </data>
   <data name="LblGameItemLevel.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -418,10 +463,13 @@
     <value>Bottom, Left</value>
   </data>
   <data name="NUDGameItemAmout.Location" type="System.Drawing.Point, System.Drawing">
-    <value>45, 213</value>
+    <value>71, 301</value>
+  </data>
+  <data name="NUDGameItemAmout.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="NUDGameItemAmout.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 23</value>
+    <value>157, 30</value>
   </data>
   <data name="NUDGameItemAmout.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -442,10 +490,13 @@
     <value>Bottom, Left</value>
   </data>
   <data name="NUDGameItemLevel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>189, 213</value>
+    <value>297, 301</value>
+  </data>
+  <data name="NUDGameItemLevel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="NUDGameItemLevel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 23</value>
+    <value>79, 30</value>
   </data>
   <data name="NUDGameItemLevel.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -469,10 +520,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblGiveCommandDescription.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 6</value>
+    <value>9, 8</value>
+  </data>
+  <data name="LblGiveCommandDescription.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblGiveCommandDescription.Size" type="System.Drawing.Size, System.Drawing">
-    <value>236, 34</value>
+    <value>352, 48</value>
   </data>
   <data name="LblGiveCommandDescription.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -497,10 +551,13 @@
     <value>NoControl</value>
   </data>
   <data name="CmbFilterItem.Location" type="System.Drawing.Point, System.Drawing">
-    <value>342, 2</value>
+    <value>537, 3</value>
+  </data>
+  <data name="CmbFilterItem.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="CmbFilterItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>150, 25</value>
+    <value>233, 32</value>
   </data>
   <data name="CmbFilterItem.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -539,10 +596,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblClearFilter.Location" type="System.Drawing.Point, System.Drawing">
-    <value>626, 6</value>
+    <value>984, 8</value>
+  </data>
+  <data name="LblClearFilter.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblClearFilter.Size" type="System.Drawing.Size, System.Drawing">
-    <value>16, 17</value>
+    <value>22, 24</value>
   </data>
   <data name="LblClearFilter.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -569,12 +629,15 @@
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>7, 17</value>
+    <value>11, 24</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1015, 337</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PageGiveItem</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>GrasscutterTools.Pages.BasePage, GrasscutterTools, Version=1.13.0.0, Culture=neutral, PublicKeyToken=de2b1c089621e923</value>
+    <value>GrasscutterTools.Pages.BasePage, GrasscutterTools, Version=1.15.2.0, Culture=neutral, PublicKeyToken=de2b1c089621e923</value>
   </data>
 </root>

--- a/Source/GrasscutterTools/Pages/PageGiveWeapon.resx
+++ b/Source/GrasscutterTools/Pages/PageGiveWeapon.resx
@@ -129,10 +129,13 @@
     <value>NoControl</value>
   </data>
   <data name="BtnGiveAllWeapons.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 173</value>
+    <value>14, 244</value>
+  </data>
+  <data name="BtnGiveAllWeapons.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="BtnGiveAllWeapons.Size" type="System.Drawing.Size, System.Drawing">
-    <value>150, 35</value>
+    <value>236, 49</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="BtnGiveAllWeapons.TabIndex" type="System.Int32, mscorlib">
@@ -157,10 +160,13 @@
     <value>Top, Right</value>
   </data>
   <data name="TxtWeaponFilter.Location" type="System.Drawing.Point, System.Drawing">
-    <value>443, 3</value>
+    <value>696, 4</value>
+  </data>
+  <data name="TxtWeaponFilter.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="TxtWeaponFilter.Size" type="System.Drawing.Size, System.Drawing">
-    <value>200, 23</value>
+    <value>312, 30</value>
   </data>
   <data name="TxtWeaponFilter.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -187,10 +193,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblWeaponDescription.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 8</value>
+    <value>9, 11</value>
+  </data>
+  <data name="LblWeaponDescription.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblWeaponDescription.Size" type="System.Drawing.Size, System.Drawing">
-    <value>200, 153</value>
+    <value>298, 216</value>
   </data>
   <data name="LblWeaponDescription.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -228,10 +237,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblWeaponRefinement.Location" type="System.Drawing.Point, System.Drawing">
-    <value>194, 216</value>
+    <value>305, 305</value>
+  </data>
+  <data name="LblWeaponRefinement.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblWeaponRefinement.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 17</value>
+    <value>82, 24</value>
   </data>
   <data name="LblWeaponRefinement.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -261,10 +273,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblWeaponAmount.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 216</value>
+    <value>9, 305</value>
+  </data>
+  <data name="LblWeaponAmount.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblWeaponAmount.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 17</value>
+    <value>46, 24</value>
   </data>
   <data name="LblWeaponAmount.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -294,10 +309,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblWeaponLevel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>100, 216</value>
+    <value>157, 305</value>
+  </data>
+  <data name="LblWeaponLevel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblWeaponLevel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 17</value>
+    <value>46, 24</value>
   </data>
   <data name="LblWeaponLevel.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -321,10 +339,13 @@
     <value>Bottom, Left</value>
   </data>
   <data name="NUDWeaponRefinement.Location" type="System.Drawing.Point, System.Drawing">
-    <value>256, 214</value>
+    <value>402, 302</value>
+  </data>
+  <data name="NUDWeaponRefinement.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="NUDWeaponRefinement.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 23</value>
+    <value>79, 30</value>
   </data>
   <data name="NUDWeaponRefinement.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -345,10 +366,13 @@
     <value>Bottom, Left</value>
   </data>
   <data name="NUDWeaponAmout.Location" type="System.Drawing.Point, System.Drawing">
-    <value>44, 214</value>
+    <value>69, 302</value>
+  </data>
+  <data name="NUDWeaponAmout.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="NUDWeaponAmout.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 23</value>
+    <value>79, 30</value>
   </data>
   <data name="NUDWeaponAmout.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -369,10 +393,13 @@
     <value>Bottom, Left</value>
   </data>
   <data name="NUDWeaponLevel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>138, 214</value>
+    <value>217, 302</value>
+  </data>
+  <data name="NUDWeaponLevel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="NUDWeaponLevel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 23</value>
+    <value>79, 30</value>
   </data>
   <data name="NUDWeaponLevel.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -393,13 +420,16 @@
     <value>Top, Bottom, Right</value>
   </data>
   <data name="ListWeapons.ItemHeight" type="System.Int32, mscorlib">
-    <value>17</value>
+    <value>24</value>
   </data>
   <data name="ListWeapons.Location" type="System.Drawing.Point, System.Drawing">
-    <value>443, 29</value>
+    <value>696, 41</value>
+  </data>
+  <data name="ListWeapons.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="ListWeapons.Size" type="System.Drawing.Size, System.Drawing">
-    <value>200, 208</value>
+    <value>312, 292</value>
   </data>
   <data name="ListWeapons.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -426,10 +456,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblClearFilter.Location" type="System.Drawing.Point, System.Drawing">
-    <value>626, 6</value>
+    <value>984, 8</value>
+  </data>
+  <data name="LblClearFilter.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblClearFilter.Size" type="System.Drawing.Size, System.Drawing">
-    <value>16, 17</value>
+    <value>22, 24</value>
   </data>
   <data name="LblClearFilter.TabIndex" type="System.Int32, mscorlib">
     <value>20</value>
@@ -456,12 +489,15 @@
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>7, 17</value>
+    <value>11, 24</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1015, 337</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PageGiveWeapon</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>GrasscutterTools.Pages.BasePage, GrasscutterTools, Version=1.13.0.0, Culture=neutral, PublicKeyToken=de2b1c089621e923</value>
+    <value>GrasscutterTools.Pages.BasePage, GrasscutterTools, Version=1.15.2.0, Culture=neutral, PublicKeyToken=de2b1c089621e923</value>
   </data>
 </root>

--- a/Source/GrasscutterTools/Pages/PageMail.Designer.cs
+++ b/Source/GrasscutterTools/Pages/PageMail.Designer.cs
@@ -34,6 +34,7 @@
             this.BtnDeleteMailItem = new System.Windows.Forms.Button();
             this.TCMailRight = new System.Windows.Forms.TabControl();
             this.TPMailSelectableItemList = new System.Windows.Forms.TabPage();
+            this.LblClearFilter = new System.Windows.Forms.Label();
             this.ListMailSelectableItems = new System.Windows.Forms.ListBox();
             this.TxtMailSelectableItemFilter = new System.Windows.Forms.TextBox();
             this.PanelMailItemArgs = new System.Windows.Forms.Panel();
@@ -59,7 +60,6 @@
             this.LblMailTitleLabel = new System.Windows.Forms.Label();
             this.TxtMailSender = new System.Windows.Forms.TextBox();
             this.LblMailSenderLabel = new System.Windows.Forms.Label();
-            this.LblClearFilter = new System.Windows.Forms.Label();
             this.TCMailRight.SuspendLayout();
             this.TPMailSelectableItemList.SuspendLayout();
             this.PanelMailItemArgs.SuspendLayout();
@@ -108,6 +108,14 @@
             resources.ApplyResources(this.TPMailSelectableItemList, "TPMailSelectableItemList");
             this.TPMailSelectableItemList.Name = "TPMailSelectableItemList";
             this.TPMailSelectableItemList.UseVisualStyleBackColor = true;
+            // 
+            // LblClearFilter
+            // 
+            resources.ApplyResources(this.LblClearFilter, "LblClearFilter");
+            this.LblClearFilter.BackColor = System.Drawing.Color.White;
+            this.LblClearFilter.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.LblClearFilter.Name = "LblClearFilter";
+            this.LblClearFilter.Click += new System.EventHandler(this.LblClearFilter_Click);
             // 
             // ListMailSelectableItems
             // 
@@ -297,14 +305,6 @@
             // 
             resources.ApplyResources(this.LblMailSenderLabel, "LblMailSenderLabel");
             this.LblMailSenderLabel.Name = "LblMailSenderLabel";
-            // 
-            // LblClearFilter
-            // 
-            resources.ApplyResources(this.LblClearFilter, "LblClearFilter");
-            this.LblClearFilter.BackColor = System.Drawing.Color.White;
-            this.LblClearFilter.Cursor = System.Windows.Forms.Cursors.Hand;
-            this.LblClearFilter.Name = "LblClearFilter";
-            this.LblClearFilter.Click += new System.EventHandler(this.LblClearFilter_Click);
             // 
             // PageMail
             // 

--- a/Source/GrasscutterTools/Pages/PageMail.resx
+++ b/Source/GrasscutterTools/Pages/PageMail.resx
@@ -127,10 +127,13 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="LblClearMailContent.Location" type="System.Drawing.Point, System.Drawing">
-    <value>384, 88</value>
+    <value>603, 124</value>
+  </data>
+  <data name="LblClearMailContent.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblClearMailContent.Size" type="System.Drawing.Size, System.Drawing">
-    <value>16, 17</value>
+    <value>22, 24</value>
   </data>
   <data name="LblClearMailContent.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -157,10 +160,13 @@
     <value>NoControl</value>
   </data>
   <data name="BtnAddMailItem.Location" type="System.Drawing.Point, System.Drawing">
-    <value>326, 147</value>
+    <value>510, 211</value>
+  </data>
+  <data name="BtnAddMailItem.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="BtnAddMailItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
+    <value>118, 32</value>
   </data>
   <data name="BtnAddMailItem.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -187,10 +193,13 @@
     <value>NoControl</value>
   </data>
   <data name="BtnDeleteMailItem.Location" type="System.Drawing.Point, System.Drawing">
-    <value>326, 176</value>
+    <value>510, 251</value>
+  </data>
+  <data name="BtnDeleteMailItem.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="BtnDeleteMailItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
+    <value>118, 32</value>
   </data>
   <data name="BtnDeleteMailItem.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -223,10 +232,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblClearFilter.Location" type="System.Drawing.Point, System.Drawing">
-    <value>206, 6</value>
+    <value>324, 8</value>
+  </data>
+  <data name="LblClearFilter.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblClearFilter.Size" type="System.Drawing.Size, System.Drawing">
-    <value>16, 17</value>
+    <value>22, 24</value>
   </data>
   <data name="LblClearFilter.TabIndex" type="System.Int32, mscorlib">
     <value>22</value>
@@ -253,16 +265,16 @@
     <value>Fill</value>
   </data>
   <data name="ListMailSelectableItems.ItemHeight" type="System.Int32, mscorlib">
-    <value>17</value>
+    <value>24</value>
   </data>
   <data name="ListMailSelectableItems.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 26</value>
+    <value>5, 34</value>
   </data>
   <data name="ListMailSelectableItems.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
   <data name="ListMailSelectableItems.Size" type="System.Drawing.Size, System.Drawing">
-    <value>222, 141</value>
+    <value>353, 208</value>
   </data>
   <data name="ListMailSelectableItems.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -283,10 +295,13 @@
     <value>Top</value>
   </data>
   <data name="TxtMailSelectableItemFilter.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
+    <value>5, 4</value>
+  </data>
+  <data name="TxtMailSelectableItemFilter.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="TxtMailSelectableItemFilter.Size" type="System.Drawing.Size, System.Drawing">
-    <value>222, 23</value>
+    <value>353, 30</value>
   </data>
   <data name="TxtMailSelectableItemFilter.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -304,10 +319,13 @@
     <value>2</value>
   </data>
   <data name="NUDMailItemLevel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>171, 5</value>
+    <value>247, 7</value>
+  </data>
+  <data name="NUDMailItemLevel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="NUDMailItemLevel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 23</value>
+    <value>79, 30</value>
   </data>
   <data name="NUDMailItemLevel.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -325,10 +343,13 @@
     <value>0</value>
   </data>
   <data name="NUDMailItemCount.Location" type="System.Drawing.Point, System.Drawing">
-    <value>47, 5</value>
+    <value>69, 7</value>
+  </data>
+  <data name="NUDMailItemCount.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="NUDMailItemCount.Size" type="System.Drawing.Size, System.Drawing">
-    <value>60, 23</value>
+    <value>94, 30</value>
   </data>
   <data name="NUDMailItemCount.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -352,10 +373,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblMailItemCount.Location" type="System.Drawing.Point, System.Drawing">
-    <value>-3, 7</value>
+    <value>-5, 10</value>
+  </data>
+  <data name="LblMailItemCount.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblMailItemCount.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 17</value>
+    <value>64, 24</value>
   </data>
   <data name="LblMailItemCount.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -382,10 +406,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblMailItemLevel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>123, 7</value>
+    <value>173, 10</value>
+  </data>
+  <data name="LblMailItemLevel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblMailItemLevel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 17</value>
+    <value>64, 24</value>
   </data>
   <data name="LblMailItemLevel.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -409,10 +436,13 @@
     <value>Bottom</value>
   </data>
   <data name="PanelMailItemArgs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 167</value>
+    <value>5, 242</value>
+  </data>
+  <data name="PanelMailItemArgs.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="PanelMailItemArgs.Size" type="System.Drawing.Size, System.Drawing">
-    <value>222, 30</value>
+    <value>353, 42</value>
   </data>
   <data name="PanelMailItemArgs.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -430,13 +460,16 @@
     <value>3</value>
   </data>
   <data name="TPMailSelectableItemList.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 26</value>
+    <value>4, 33</value>
+  </data>
+  <data name="TPMailSelectableItemList.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="TPMailSelectableItemList.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="TPMailSelectableItemList.Size" type="System.Drawing.Size, System.Drawing">
-    <value>228, 200</value>
+    <value>363, 288</value>
   </data>
   <data name="TPMailSelectableItemList.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -456,20 +489,98 @@
   <data name="&gt;&gt;TPMailSelectableItemList.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="&gt;&gt;ListMailList.Name" xml:space="preserve">
+    <value>ListMailList</value>
+  </data>
+  <data name="&gt;&gt;ListMailList.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ListMailList.Parent" xml:space="preserve">
+    <value>TPMailList</value>
+  </data>
+  <data name="&gt;&gt;ListMailList.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;PanelMailListControls.Name" xml:space="preserve">
+    <value>PanelMailListControls</value>
+  </data>
+  <data name="&gt;&gt;PanelMailListControls.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;PanelMailListControls.Parent" xml:space="preserve">
+    <value>TPMailList</value>
+  </data>
+  <data name="&gt;&gt;PanelMailListControls.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="TPMailList.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 33</value>
+  </data>
+  <data name="TPMailList.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="TPMailList.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="TPMailList.Size" type="System.Drawing.Size, System.Drawing">
+    <value>363, 288</value>
+  </data>
+  <data name="TPMailList.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="TPMailList.Text" xml:space="preserve">
+    <value>邮件列表</value>
+  </data>
+  <data name="&gt;&gt;TPMailList.Name" xml:space="preserve">
+    <value>TPMailList</value>
+  </data>
+  <data name="&gt;&gt;TPMailList.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;TPMailList.Parent" xml:space="preserve">
+    <value>TCMailRight</value>
+  </data>
+  <data name="&gt;&gt;TPMailList.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="TCMailRight.Location" type="System.Drawing.Point, System.Drawing">
+    <value>640, 6</value>
+  </data>
+  <data name="TCMailRight.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="TCMailRight.Size" type="System.Drawing.Size, System.Drawing">
+    <value>371, 325</value>
+  </data>
+  <data name="TCMailRight.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="&gt;&gt;TCMailRight.Name" xml:space="preserve">
+    <value>TCMailRight</value>
+  </data>
+  <data name="&gt;&gt;TCMailRight.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;TCMailRight.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;TCMailRight.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
   <data name="ListMailList.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
   <data name="ListMailList.ItemHeight" type="System.Int32, mscorlib">
-    <value>17</value>
+    <value>24</value>
   </data>
   <data name="ListMailList.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
+    <value>5, 4</value>
   </data>
   <data name="ListMailList.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
   <data name="ListMailList.Size" type="System.Drawing.Size, System.Drawing">
-    <value>222, 166</value>
+    <value>353, 240</value>
   </data>
   <data name="ListMailList.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -486,14 +597,68 @@
   <data name="&gt;&gt;ListMailList.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="&gt;&gt;BtnClearMail.Name" xml:space="preserve">
+    <value>BtnClearMail</value>
+  </data>
+  <data name="&gt;&gt;BtnClearMail.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;BtnClearMail.Parent" xml:space="preserve">
+    <value>PanelMailListControls</value>
+  </data>
+  <data name="&gt;&gt;BtnClearMail.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;BtnRemoveMail.Name" xml:space="preserve">
+    <value>BtnRemoveMail</value>
+  </data>
+  <data name="&gt;&gt;BtnRemoveMail.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;BtnRemoveMail.Parent" xml:space="preserve">
+    <value>PanelMailListControls</value>
+  </data>
+  <data name="&gt;&gt;BtnRemoveMail.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="PanelMailListControls.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Bottom</value>
+  </data>
+  <data name="PanelMailListControls.Location" type="System.Drawing.Point, System.Drawing">
+    <value>5, 244</value>
+  </data>
+  <data name="PanelMailListControls.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="PanelMailListControls.Size" type="System.Drawing.Size, System.Drawing">
+    <value>353, 40</value>
+  </data>
+  <data name="PanelMailListControls.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;PanelMailListControls.Name" xml:space="preserve">
+    <value>PanelMailListControls</value>
+  </data>
+  <data name="&gt;&gt;PanelMailListControls.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;PanelMailListControls.Parent" xml:space="preserve">
+    <value>TPMailList</value>
+  </data>
+  <data name="&gt;&gt;PanelMailListControls.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
   <data name="BtnClearMail.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="BtnClearMail.Location" type="System.Drawing.Point, System.Drawing">
-    <value>84, 3</value>
+    <value>132, 4</value>
+  </data>
+  <data name="BtnClearMail.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="BtnClearMail.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
+    <value>118, 32</value>
   </data>
   <data name="BtnClearMail.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -517,10 +682,13 @@
     <value>NoControl</value>
   </data>
   <data name="BtnRemoveMail.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
+    <value>5, 4</value>
+  </data>
+  <data name="BtnRemoveMail.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="BtnRemoveMail.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
+    <value>118, 32</value>
   </data>
   <data name="BtnRemoveMail.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -540,78 +708,6 @@
   <data name="&gt;&gt;BtnRemoveMail.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="PanelMailListControls.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Bottom</value>
-  </data>
-  <data name="PanelMailListControls.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 169</value>
-  </data>
-  <data name="PanelMailListControls.Size" type="System.Drawing.Size, System.Drawing">
-    <value>222, 28</value>
-  </data>
-  <data name="PanelMailListControls.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;PanelMailListControls.Name" xml:space="preserve">
-    <value>PanelMailListControls</value>
-  </data>
-  <data name="&gt;&gt;PanelMailListControls.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;PanelMailListControls.Parent" xml:space="preserve">
-    <value>TPMailList</value>
-  </data>
-  <data name="&gt;&gt;PanelMailListControls.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="TPMailList.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 26</value>
-  </data>
-  <data name="TPMailList.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="TPMailList.Size" type="System.Drawing.Size, System.Drawing">
-    <value>228, 200</value>
-  </data>
-  <data name="TPMailList.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="TPMailList.Text" xml:space="preserve">
-    <value>邮件列表</value>
-  </data>
-  <data name="&gt;&gt;TPMailList.Name" xml:space="preserve">
-    <value>TPMailList</value>
-  </data>
-  <data name="&gt;&gt;TPMailList.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;TPMailList.Parent" xml:space="preserve">
-    <value>TCMailRight</value>
-  </data>
-  <data name="&gt;&gt;TPMailList.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="TCMailRight.Location" type="System.Drawing.Point, System.Drawing">
-    <value>407, 4</value>
-  </data>
-  <data name="TCMailRight.Size" type="System.Drawing.Size, System.Drawing">
-    <value>236, 230</value>
-  </data>
-  <data name="TCMailRight.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;TCMailRight.Name" xml:space="preserve">
-    <value>TCMailRight</value>
-  </data>
-  <data name="&gt;&gt;TCMailRight.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;TCMailRight.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;TCMailRight.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
   <data name="BtnSendMail.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
   </data>
@@ -619,10 +715,13 @@
     <value>NoControl</value>
   </data>
   <data name="BtnSendMail.Location" type="System.Drawing.Point, System.Drawing">
-    <value>326, 202</value>
+    <value>510, 288</value>
+  </data>
+  <data name="BtnSendMail.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="BtnSendMail.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 32</value>
+    <value>118, 38</value>
   </data>
   <data name="BtnSendMail.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -646,13 +745,16 @@
     <value>Bottom, Left</value>
   </data>
   <data name="ListMailItems.ItemHeight" type="System.Int32, mscorlib">
-    <value>17</value>
+    <value>24</value>
   </data>
   <data name="ListMailItems.Location" type="System.Drawing.Point, System.Drawing">
-    <value>70, 147</value>
+    <value>110, 211</value>
+  </data>
+  <data name="ListMailItems.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="ListMailItems.Size" type="System.Drawing.Size, System.Drawing">
-    <value>250, 89</value>
+    <value>391, 100</value>
   </data>
   <data name="ListMailItems.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -679,10 +781,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblMailItemsLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 150</value>
+    <value>5, 212</value>
+  </data>
+  <data name="LblMailItemsLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblMailItemsLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 17</value>
+    <value>64, 24</value>
   </data>
   <data name="LblMailItemsLabel.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -703,10 +808,13 @@
     <value>6</value>
   </data>
   <data name="NUDMailRecipient.Location" type="System.Drawing.Point, System.Drawing">
-    <value>280, 31</value>
+    <value>440, 44</value>
+  </data>
+  <data name="NUDMailRecipient.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="NUDMailRecipient.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 23</value>
+    <value>190, 30</value>
   </data>
   <data name="NUDMailRecipient.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -730,10 +838,13 @@
     <value>NoControl</value>
   </data>
   <data name="RbMailSendToPlayer.Location" type="System.Drawing.Point, System.Drawing">
-    <value>224, 31</value>
+    <value>352, 44</value>
+  </data>
+  <data name="RbMailSendToPlayer.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="RbMailSendToPlayer.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 21</value>
+    <value>71, 28</value>
   </data>
   <data name="RbMailSendToPlayer.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -760,10 +871,13 @@
     <value>NoControl</value>
   </data>
   <data name="RbMailSendToAll.Location" type="System.Drawing.Point, System.Drawing">
-    <value>75, 31</value>
+    <value>118, 44</value>
+  </data>
+  <data name="RbMailSendToAll.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="RbMailSendToAll.Size" type="System.Drawing.Size, System.Drawing">
-    <value>62, 21</value>
+    <value>89, 28</value>
   </data>
   <data name="RbMailSendToAll.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -790,10 +904,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblMailRecipientLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 33</value>
+    <value>5, 47</value>
+  </data>
+  <data name="LblMailRecipientLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblMailRecipientLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 17</value>
+    <value>82, 24</value>
   </data>
   <data name="LblMailRecipientLabel.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -817,7 +934,10 @@
     <value>Top, Bottom, Left</value>
   </data>
   <data name="TxtMailContent.Location" type="System.Drawing.Point, System.Drawing">
-    <value>70, 89</value>
+    <value>110, 126</value>
+  </data>
+  <data name="TxtMailContent.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="TxtMailContent.Multiline" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -826,7 +946,7 @@
     <value>Vertical</value>
   </data>
   <data name="TxtMailContent.Size" type="System.Drawing.Size, System.Drawing">
-    <value>331, 52</value>
+    <value>518, 72</value>
   </data>
   <data name="TxtMailContent.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -850,10 +970,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblMailContentLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 92</value>
+    <value>5, 130</value>
+  </data>
+  <data name="LblMailContentLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblMailContentLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 17</value>
+    <value>64, 24</value>
   </data>
   <data name="LblMailContentLabel.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -874,10 +997,13 @@
     <value>12</value>
   </data>
   <data name="TxtMailTitle.Location" type="System.Drawing.Point, System.Drawing">
-    <value>70, 60</value>
+    <value>110, 85</value>
+  </data>
+  <data name="TxtMailTitle.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="TxtMailTitle.Size" type="System.Drawing.Size, System.Drawing">
-    <value>331, 23</value>
+    <value>518, 30</value>
   </data>
   <data name="TxtMailTitle.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -901,10 +1027,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblMailTitleLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 63</value>
+    <value>5, 89</value>
+  </data>
+  <data name="LblMailTitleLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblMailTitleLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 17</value>
+    <value>64, 24</value>
   </data>
   <data name="LblMailTitleLabel.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -925,10 +1054,13 @@
     <value>14</value>
   </data>
   <data name="TxtMailSender.Location" type="System.Drawing.Point, System.Drawing">
-    <value>70, 2</value>
+    <value>110, 3</value>
+  </data>
+  <data name="TxtMailSender.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="TxtMailSender.Size" type="System.Drawing.Size, System.Drawing">
-    <value>331, 23</value>
+    <value>518, 30</value>
   </data>
   <data name="TxtMailSender.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -952,10 +1084,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblMailSenderLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 5</value>
+    <value>5, 7</value>
+  </data>
+  <data name="LblMailSenderLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblMailSenderLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 17</value>
+    <value>82, 24</value>
   </data>
   <data name="LblMailSenderLabel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -979,12 +1114,15 @@
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>7, 17</value>
+    <value>11, 24</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1015, 337</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PageMail</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>GrasscutterTools.Pages.BasePage, GrasscutterTools, Version=1.13.0.0, Culture=neutral, PublicKeyToken=de2b1c089621e923</value>
+    <value>GrasscutterTools.Pages.BasePage, GrasscutterTools, Version=1.15.2.0, Culture=neutral, PublicKeyToken=de2b1c089621e923</value>
   </data>
 </root>

--- a/Source/GrasscutterTools/Pages/PageOpenCommand.resx
+++ b/Source/GrasscutterTools/Pages/PageOpenCommand.resx
@@ -130,10 +130,13 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="LnkLinks.Location" type="System.Drawing.Point, System.Drawing">
-    <value>436, 204</value>
+    <value>685, 288</value>
+  </data>
+  <data name="LnkLinks.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LnkLinks.Size" type="System.Drawing.Size, System.Drawing">
-    <value>37, 17</value>
+    <value>53, 24</value>
   </data>
   <data name="LnkLinks.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -163,10 +166,13 @@
     <value>NoControl</value>
   </data>
   <data name="LnkGOODHelp.Location" type="System.Drawing.Point, System.Drawing">
-    <value>384, 204</value>
+    <value>603, 288</value>
+  </data>
+  <data name="LnkGOODHelp.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LnkGOODHelp.Size" type="System.Drawing.Size, System.Drawing">
-    <value>46, 17</value>
+    <value>67, 24</value>
   </data>
   <data name="LnkGOODHelp.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -193,10 +199,13 @@
     <value>NoControl</value>
   </data>
   <data name="LnkInventoryKamera.Location" type="System.Drawing.Point, System.Drawing">
-    <value>478, 181</value>
+    <value>744, 256</value>
+  </data>
+  <data name="LnkInventoryKamera.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LnkInventoryKamera.Size" type="System.Drawing.Size, System.Drawing">
-    <value>107, 17</value>
+    <value>168, 24</value>
   </data>
   <data name="LnkInventoryKamera.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -223,10 +232,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblGOODHelp.Location" type="System.Drawing.Point, System.Drawing">
-    <value>380, 137</value>
+    <value>597, 193</value>
+  </data>
+  <data name="LblGOODHelp.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblGOODHelp.Size" type="System.Drawing.Size, System.Drawing">
-    <value>205, 58</value>
+    <value>322, 82</value>
   </data>
   <data name="LblGOODHelp.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -253,10 +265,13 @@
     <value>NoControl</value>
   </data>
   <data name="ButtonOpenGOODImport.Location" type="System.Drawing.Point, System.Drawing">
-    <value>476, 201</value>
+    <value>748, 284</value>
+  </data>
+  <data name="ButtonOpenGOODImport.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="ButtonOpenGOODImport.Size" type="System.Drawing.Size, System.Drawing">
-    <value>104, 23</value>
+    <value>163, 32</value>
   </data>
   <data name="ButtonOpenGOODImport.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -286,10 +301,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblHostTip.Location" type="System.Drawing.Point, System.Drawing">
-    <value>133, 14</value>
+    <value>209, 20</value>
+  </data>
+  <data name="LblHostTip.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblHostTip.Size" type="System.Drawing.Size, System.Drawing">
-    <value>210, 17</value>
+    <value>314, 24</value>
   </data>
   <data name="LblHostTip.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -319,10 +337,13 @@
     <value>NoControl</value>
   </data>
   <data name="LnkOpenCommandLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 62</value>
+    <value>20, 88</value>
+  </data>
+  <data name="LnkOpenCommandLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LnkOpenCommandLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 17</value>
+    <value>118, 24</value>
   </data>
   <data name="LnkOpenCommandLabel.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -349,10 +370,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblOpenCommandSupport.Location" type="System.Drawing.Point, System.Drawing">
-    <value>99, 62</value>
+    <value>156, 88</value>
+  </data>
+  <data name="LblOpenCommandSupport.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblOpenCommandSupport.Size" type="System.Drawing.Size, System.Drawing">
-    <value>23, 17</value>
+    <value>34, 24</value>
   </data>
   <data name="LblOpenCommandSupport.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -379,10 +403,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblServerVersion.Location" type="System.Drawing.Point, System.Drawing">
-    <value>99, 28</value>
+    <value>156, 40</value>
+  </data>
+  <data name="LblServerVersion.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblServerVersion.Size" type="System.Drawing.Size, System.Drawing">
-    <value>23, 17</value>
+    <value>34, 24</value>
   </data>
   <data name="LblServerVersion.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -409,10 +436,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblPlayerCount.Location" type="System.Drawing.Point, System.Drawing">
-    <value>99, 45</value>
+    <value>156, 64</value>
+  </data>
+  <data name="LblPlayerCount.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblPlayerCount.Size" type="System.Drawing.Size, System.Drawing">
-    <value>23, 17</value>
+    <value>34, 24</value>
   </data>
   <data name="LblPlayerCount.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -439,10 +469,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblServerVersionLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>37, 28</value>
+    <value>58, 40</value>
+  </data>
+  <data name="LblServerVersionLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblServerVersionLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 17</value>
+    <value>82, 24</value>
   </data>
   <data name="LblServerVersionLabel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -469,10 +502,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblPlayerCountLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>25, 45</value>
+    <value>39, 64</value>
+  </data>
+  <data name="LblPlayerCountLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblPlayerCountLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>68, 17</value>
+    <value>100, 24</value>
   </data>
   <data name="LblPlayerCountLabel.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -493,10 +529,16 @@
     <value>5</value>
   </data>
   <data name="GrpServerStatus.Location" type="System.Drawing.Point, System.Drawing">
-    <value>380, 34</value>
+    <value>597, 48</value>
+  </data>
+  <data name="GrpServerStatus.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="GrpServerStatus.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="GrpServerStatus.Size" type="System.Drawing.Size, System.Drawing">
-    <value>200, 100</value>
+    <value>314, 141</value>
   </data>
   <data name="GrpServerStatus.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -526,10 +568,13 @@
     <value>NoControl</value>
   </data>
   <data name="LnkRCHelp.Location" type="System.Drawing.Point, System.Drawing">
-    <value>189, 15</value>
+    <value>297, 21</value>
+  </data>
+  <data name="LnkRCHelp.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LnkRCHelp.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 17</value>
+    <value>46, 24</value>
   </data>
   <data name="LnkRCHelp.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -550,10 +595,13 @@
     <value>0</value>
   </data>
   <data name="NUDRemotePlayerId.Location" type="System.Drawing.Point, System.Drawing">
-    <value>65, 13</value>
+    <value>102, 18</value>
+  </data>
+  <data name="NUDRemotePlayerId.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="NUDRemotePlayerId.Size" type="System.Drawing.Size, System.Drawing">
-    <value>118, 23</value>
+    <value>185, 30</value>
   </data>
   <data name="NUDRemotePlayerId.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -577,10 +625,13 @@
     <value>NoControl</value>
   </data>
   <data name="BtnConnectOpenCommand.Location" type="System.Drawing.Point, System.Drawing">
-    <value>92, 82</value>
+    <value>145, 116</value>
+  </data>
+  <data name="BtnConnectOpenCommand.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="BtnConnectOpenCommand.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 23</value>
+    <value>157, 32</value>
   </data>
   <data name="BtnConnectOpenCommand.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -607,10 +658,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblVerificationCode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 44</value>
+    <value>24, 62</value>
+  </data>
+  <data name="LblVerificationCode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblVerificationCode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 17</value>
+    <value>64, 24</value>
   </data>
   <data name="LblVerificationCode.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -634,10 +688,13 @@
     <value>NoControl</value>
   </data>
   <data name="BtnSendVerificationCode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>189, 42</value>
+    <value>297, 59</value>
+  </data>
+  <data name="BtnSendVerificationCode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="BtnSendVerificationCode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 23</value>
+    <value>157, 32</value>
   </data>
   <data name="BtnSendVerificationCode.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -661,10 +718,13 @@
     <value>False</value>
   </data>
   <data name="NUDVerificationCode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>65, 42</value>
+    <value>102, 59</value>
+  </data>
+  <data name="NUDVerificationCode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="NUDVerificationCode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>118, 23</value>
+    <value>185, 30</value>
   </data>
   <data name="NUDVerificationCode.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -688,10 +748,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblRemotePlayerId.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 15</value>
+    <value>46, 21</value>
+  </data>
+  <data name="LblRemotePlayerId.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblRemotePlayerId.Size" type="System.Drawing.Size, System.Drawing">
-    <value>30, 17</value>
+    <value>42, 24</value>
   </data>
   <data name="LblRemotePlayerId.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -712,13 +775,16 @@
     <value>6</value>
   </data>
   <data name="TPPlayerCheck.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 26</value>
+    <value>4, 33</value>
+  </data>
+  <data name="TPPlayerCheck.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="TPPlayerCheck.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="TPPlayerCheck.Size" type="System.Drawing.Size, System.Drawing">
-    <value>296, 109</value>
+    <value>469, 159</value>
   </data>
   <data name="TPPlayerCheck.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -742,10 +808,13 @@
     <value>NoControl</value>
   </data>
   <data name="BtnConsoleConnect.Location" type="System.Drawing.Point, System.Drawing">
-    <value>92, 82</value>
+    <value>145, 116</value>
+  </data>
+  <data name="BtnConsoleConnect.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="BtnConsoleConnect.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 23</value>
+    <value>157, 32</value>
   </data>
   <data name="BtnConsoleConnect.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -766,10 +835,13 @@
     <value>0</value>
   </data>
   <data name="TxtToken.Location" type="System.Drawing.Point, System.Drawing">
-    <value>65, 13</value>
+    <value>102, 18</value>
+  </data>
+  <data name="TxtToken.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="TxtToken.Size" type="System.Drawing.Size, System.Drawing">
-    <value>182, 23</value>
+    <value>284, 30</value>
   </data>
   <data name="TxtToken.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -793,10 +865,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblToken.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 16</value>
+    <value>24, 23</value>
+  </data>
+  <data name="LblToken.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblToken.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 17</value>
+    <value>62, 24</value>
   </data>
   <data name="LblToken.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -823,10 +898,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblConsoleTip.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 39</value>
+    <value>24, 55</value>
+  </data>
+  <data name="LblConsoleTip.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblConsoleTip.Size" type="System.Drawing.Size, System.Drawing">
-    <value>275, 40</value>
+    <value>432, 56</value>
   </data>
   <data name="LblConsoleTip.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -848,13 +926,16 @@
     <value>3</value>
   </data>
   <data name="TPConsoleCheck.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 26</value>
+    <value>4, 33</value>
+  </data>
+  <data name="TPConsoleCheck.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="TPConsoleCheck.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="TPConsoleCheck.Size" type="System.Drawing.Size, System.Drawing">
-    <value>296, 111</value>
+    <value>470, 152</value>
   </data>
   <data name="TPConsoleCheck.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -878,10 +959,13 @@
     <value>Fill</value>
   </data>
   <data name="TPOpenCommandCheck.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 19</value>
+    <value>5, 27</value>
+  </data>
+  <data name="TPOpenCommandCheck.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="TPOpenCommandCheck.Size" type="System.Drawing.Size, System.Drawing">
-    <value>304, 139</value>
+    <value>477, 196</value>
   </data>
   <data name="TPOpenCommandCheck.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -902,10 +986,16 @@
     <value>False</value>
   </data>
   <data name="GrpRemoteCommand.Location" type="System.Drawing.Point, System.Drawing">
-    <value>64, 63</value>
+    <value>101, 89</value>
+  </data>
+  <data name="GrpRemoteCommand.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="GrpRemoteCommand.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="GrpRemoteCommand.Size" type="System.Drawing.Size, System.Drawing">
-    <value>310, 161</value>
+    <value>487, 227</value>
   </data>
   <data name="GrpRemoteCommand.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -929,10 +1019,13 @@
     <value>None</value>
   </data>
   <data name="TxtHost.Location" type="System.Drawing.Point, System.Drawing">
-    <value>136, 34</value>
+    <value>214, 48</value>
+  </data>
+  <data name="TxtHost.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="TxtHost.Size" type="System.Drawing.Size, System.Drawing">
-    <value>182, 25</value>
+    <value>284, 32</value>
   </data>
   <data name="TxtHost.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -956,10 +1049,13 @@
     <value>NoControl</value>
   </data>
   <data name="BtnQueryServerStatus.Location" type="System.Drawing.Point, System.Drawing">
-    <value>324, 34</value>
+    <value>509, 48</value>
+  </data>
+  <data name="BtnQueryServerStatus.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="BtnQueryServerStatus.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 25</value>
+    <value>79, 35</value>
   </data>
   <data name="BtnQueryServerStatus.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -989,10 +1085,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblHost.Location" type="System.Drawing.Point, System.Drawing">
-    <value>62, 37</value>
+    <value>97, 52</value>
+  </data>
+  <data name="LblHost.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblHost.Size" type="System.Drawing.Size, System.Drawing">
-    <value>68, 17</value>
+    <value>100, 24</value>
   </data>
   <data name="LblHost.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -1016,12 +1115,15 @@
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>7, 17</value>
+    <value>11, 24</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1015, 337</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PageOpenCommand</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>GrasscutterTools.Pages.BasePage, GrasscutterTools, Version=1.13.0.0, Culture=neutral, PublicKeyToken=de2b1c089621e923</value>
+    <value>GrasscutterTools.Pages.BasePage, GrasscutterTools, Version=1.15.2.0, Culture=neutral, PublicKeyToken=de2b1c089621e923</value>
   </data>
 </root>

--- a/Source/GrasscutterTools/Pages/PageProxy.resx
+++ b/Source/GrasscutterTools/Pages/PageProxy.resx
@@ -123,10 +123,13 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="TxtHost.Location" type="System.Drawing.Point, System.Drawing">
-    <value>227, 40</value>
+    <value>357, 56</value>
+  </data>
+  <data name="TxtHost.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="TxtHost.Size" type="System.Drawing.Size, System.Drawing">
-    <value>160, 23</value>
+    <value>249, 30</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="TxtHost.TabIndex" type="System.Int32, mscorlib">
@@ -151,10 +154,13 @@
     <value>True</value>
   </data>
   <data name="LblServerAddress.Location" type="System.Drawing.Point, System.Drawing">
-    <value>84, 43</value>
+    <value>132, 61</value>
+  </data>
+  <data name="LblServerAddress.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblServerAddress.Size" type="System.Drawing.Size, System.Drawing">
-    <value>137, 17</value>
+    <value>203, 24</value>
   </data>
   <data name="LblServerAddress.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -178,10 +184,13 @@
     <value>Top, Right</value>
   </data>
   <data name="BtnStartProxy.Location" type="System.Drawing.Point, System.Drawing">
-    <value>393, 40</value>
+    <value>618, 56</value>
+  </data>
+  <data name="BtnStartProxy.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="BtnStartProxy.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 25</value>
+    <value>189, 35</value>
   </data>
   <data name="BtnStartProxy.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -208,10 +217,13 @@
     <value>True</value>
   </data>
   <data name="ChkAutoStart.Location" type="System.Drawing.Point, System.Drawing">
-    <value>519, 42</value>
+    <value>826, 59</value>
+  </data>
+  <data name="ChkAutoStart.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="ChkAutoStart.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 21</value>
+    <value>108, 28</value>
   </data>
   <data name="ChkAutoStart.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -235,7 +247,10 @@
     <value>Top, Bottom, Left, Right</value>
   </data>
   <data name="LblProxyIntroduction.Location" type="System.Drawing.Point, System.Drawing">
-    <value>48, 72</value>
+    <value>75, 102</value>
+  </data>
+  <data name="LblProxyIntroduction.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="LblProxyIntroduction.Multiline" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -244,7 +259,7 @@
     <value>Vertical</value>
   </data>
   <data name="LblProxyIntroduction.Size" type="System.Drawing.Size, System.Drawing">
-    <value>550, 120</value>
+    <value>862, 182</value>
   </data>
   <data name="LblProxyIntroduction.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -271,10 +286,13 @@
     <value>Bottom, Right</value>
   </data>
   <data name="BtnDestroyCert.Location" type="System.Drawing.Point, System.Drawing">
-    <value>529, 207</value>
+    <value>831, 292</value>
+  </data>
+  <data name="BtnDestroyCert.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="BtnDestroyCert.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 25</value>
+    <value>157, 35</value>
   </data>
   <data name="BtnDestroyCert.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -301,10 +319,13 @@
     <value>True</value>
   </data>
   <data name="LnkEavesdrop.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 211</value>
+    <value>24, 298</value>
+  </data>
+  <data name="LnkEavesdrop.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LnkEavesdrop.Size" type="System.Drawing.Size, System.Drawing">
-    <value>70, 17</value>
+    <value>99, 24</value>
   </data>
   <data name="LnkEavesdrop.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -331,10 +352,13 @@
     <value>True</value>
   </data>
   <data name="LnkAbout.Location" type="System.Drawing.Point, System.Drawing">
-    <value>482, 211</value>
+    <value>757, 298</value>
+  </data>
+  <data name="LnkAbout.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LnkAbout.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 17</value>
+    <value>46, 24</value>
   </data>
   <data name="LnkAbout.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -358,10 +382,13 @@
     <value>True</value>
   </data>
   <data name="LblGcJarPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>102, 14</value>
+    <value>160, 20</value>
+  </data>
+  <data name="LblGcJarPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblGcJarPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>119, 17</value>
+    <value>172, 24</value>
   </data>
   <data name="LblGcJarPath.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -388,10 +415,13 @@
     <value>Top, Left, Right</value>
   </data>
   <data name="TxtGcJarPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>227, 11</value>
+    <value>357, 16</value>
+  </data>
+  <data name="TxtGcJarPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="TxtGcJarPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>160, 23</value>
+    <value>249, 30</value>
   </data>
   <data name="TxtGcJarPath.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -415,10 +445,13 @@
     <value>Top, Right</value>
   </data>
   <data name="BtnStartGc.Location" type="System.Drawing.Point, System.Drawing">
-    <value>393, 11</value>
+    <value>618, 16</value>
+  </data>
+  <data name="BtnStartGc.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="BtnStartGc.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 25</value>
+    <value>189, 35</value>
   </data>
   <data name="BtnStartGc.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -445,15 +478,18 @@
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>7, 17</value>
+    <value>11, 24</value>
   </data>
   <data name="$this.AutoScroll" type="System.Boolean, mscorlib">
     <value>True</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1015, 337</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PageProxy</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>GrasscutterTools.Pages.BasePage, GrasscutterTools, Version=1.13.0.0, Culture=neutral, PublicKeyToken=de2b1c089621e923</value>
+    <value>GrasscutterTools.Pages.BasePage, GrasscutterTools, Version=1.15.2.0, Culture=neutral, PublicKeyToken=de2b1c089621e923</value>
   </data>
 </root>

--- a/Source/GrasscutterTools/Pages/PageQuest.resx
+++ b/Source/GrasscutterTools/Pages/PageQuest.resx
@@ -117,340 +117,367 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="ChkQuestFilterUNRELEASED.Location" type="System.Drawing.Point, System.Drawing">
-    <value>26, 55</value>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="GrpQuestFilters.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="TxtQuestFilter.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;BtnAddQuest.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="BtnAddQuest.Text" xml:space="preserve">
-    <value>添加任务</value>
-  </data>
-  <data name="TxtQuestFilter.Size" type="System.Drawing.Size, System.Drawing">
-    <value>288, 23</value>
-  </data>
-  <data name="&gt;&gt;TxtQuestFilter.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>GrasscutterTools.Pages.BasePage, GrasscutterTools, Version=1.15.1.0, Culture=neutral, PublicKeyToken=de2b1c089621e923</value>
-  </data>
-  <data name="&gt;&gt;ChkQuestFilterUNRELEASED.Name" xml:space="preserve">
-    <value>ChkQuestFilterUNRELEASED</value>
-  </data>
-  <data name="ChkQuestFilterUNRELEASED.Size" type="System.Drawing.Size, System.Drawing">
-    <value>99, 21</value>
-  </data>
-  <data name="ChkQuestFilterHIDDEN.Location" type="System.Drawing.Point, System.Drawing">
-    <value>26, 28</value>
-  </data>
-  <data name="&gt;&gt;TxtQuestFilter.Name" xml:space="preserve">
-    <value>TxtQuestFilter</value>
-  </data>
-  <data name="LblClearFilter.TabIndex" type="System.Int32, mscorlib">
-    <value>22</value>
-  </data>
-  <data name="LblQuestDescription.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="LblClearFilter.Location" type="System.Drawing.Point, System.Drawing">
-    <value>626, 5</value>
-  </data>
-  <data name="&gt;&gt;ChkQuestFilterTEST.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ListQuest.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="ListQuest.ItemHeight" type="System.Int32, mscorlib">
-    <value>17</value>
-  </data>
-  <data name="BtnFinishQuest.Size" type="System.Drawing.Size, System.Drawing">
-    <value>90, 23</value>
-  </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="LblQuestDescription.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left</value>
+  <data name="ChkQuestFilterTEST.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="ChkQuestFilterTEST.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="&gt;&gt;LblQuestDescription.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>7, 17</value>
-  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="ChkQuestFilterTEST.Location" type="System.Drawing.Point, System.Drawing">
-    <value>26, 82</value>
+    <value>41, 116</value>
   </data>
-  <data name="GrpQuestFilters.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Left</value>
-  </data>
-  <data name="&gt;&gt;GrpQuestFilters.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;BtnAddQuest.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;BtnFinishQuest.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="ChkQuestFilterTEST.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="ChkQuestFilterTEST.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 21</value>
-  </data>
-  <data name="&gt;&gt;GrpQuestFilters.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="LblClearFilter.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="ChkAddAndFinishQuest.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;LblClearFilter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ChkQuestFilterHIDDEN.Parent" xml:space="preserve">
-    <value>GrpQuestFilters</value>
-  </data>
-  <data name="BtnAddQuest.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Left</value>
-  </data>
-  <data name="&gt;&gt;ListQuest.Name" xml:space="preserve">
-    <value>ListQuest</value>
-  </data>
-  <data name="&gt;&gt;ChkQuestFilterTEST.Parent" xml:space="preserve">
-    <value>GrpQuestFilters</value>
-  </data>
-  <data name="&gt;&gt;GrpQuestFilters.Name" xml:space="preserve">
-    <value>GrpQuestFilters</value>
-  </data>
-  <data name="BtnFinishQuest.Text" xml:space="preserve">
-    <value>完成任务</value>
-  </data>
-  <data name="GrpQuestFilters.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;ChkQuestFilterHIDDEN.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="GrpQuestFilters.Text" xml:space="preserve">
-    <value>列表过滤</value>
-  </data>
-  <data name="BtnFinishQuest.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;ChkAddAndFinishQuest.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="ChkQuestFilterUNRELEASED.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;ChkQuestFilterUNRELEASED.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="ChkAddAndFinishQuest.Text" xml:space="preserve">
-    <value>选中时添加并完成</value>
-  </data>
-  <data name="ListQuest.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="GrpQuestFilters.Location" type="System.Drawing.Point, System.Drawing">
-    <value>199, 106</value>
-  </data>
-  <data name="ChkQuestFilterHIDDEN.Size" type="System.Drawing.Size, System.Drawing">
-    <value>87, 21</value>
-  </data>
-  <data name="ChkAddAndFinishQuest.TabIndex" type="System.Int32, mscorlib">
-    <value>23</value>
-  </data>
-  <data name="&gt;&gt;ChkAddAndFinishQuest.Name" xml:space="preserve">
-    <value>ChkAddAndFinishQuest</value>
-  </data>
-  <data name="ChkAddAndFinishQuest.Size" type="System.Drawing.Size, System.Drawing">
-    <value>123, 21</value>
-  </data>
-  <data name="&gt;&gt;ChkQuestFilterTEST.Name" xml:space="preserve">
-    <value>ChkQuestFilterTEST</value>
-  </data>
-  <data name="&gt;&gt;GrpQuestFilters.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="ChkQuestFilterHIDDEN.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="BtnAddQuest.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="ListQuest.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
-  </data>
-  <data name="LblQuestDescription.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;LblQuestDescription.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>108, 28</value>
   </data>
   <data name="ChkQuestFilterTEST.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
-  <data name="LblQuestDescription.Size" type="System.Drawing.Size, System.Drawing">
-    <value>346, 100</value>
-  </data>
   <data name="ChkQuestFilterTEST.Text" xml:space="preserve">
     <value>测试任务</value>
   </data>
-  <data name="ChkAddAndFinishQuest.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 186</value>
+  <data name="&gt;&gt;ChkQuestFilterTEST.Name" xml:space="preserve">
+    <value>ChkQuestFilterTEST</value>
   </data>
-  <data name="LblClearFilter.Size" type="System.Drawing.Size, System.Drawing">
-    <value>16, 17</value>
+  <data name="&gt;&gt;ChkQuestFilterTEST.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="ChkQuestFilterTEST.AutoSize" type="System.Boolean, mscorlib">
+  <data name="&gt;&gt;ChkQuestFilterTEST.Parent" xml:space="preserve">
+    <value>GrpQuestFilters</value>
+  </data>
+  <data name="&gt;&gt;ChkQuestFilterTEST.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="ChkQuestFilterUNRELEASED.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="ListQuest.Size" type="System.Drawing.Size, System.Drawing">
-    <value>288, 208</value>
+  <data name="ChkQuestFilterUNRELEASED.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="ChkQuestFilterUNRELEASED.Location" type="System.Drawing.Point, System.Drawing">
+    <value>41, 78</value>
+  </data>
+  <data name="ChkQuestFilterUNRELEASED.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="ChkQuestFilterUNRELEASED.Size" type="System.Drawing.Size, System.Drawing">
+    <value>144, 28</value>
+  </data>
+  <data name="ChkQuestFilterUNRELEASED.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="ChkQuestFilterUNRELEASED.Text" xml:space="preserve">
+    <value>未发布的任务</value>
+  </data>
+  <data name="&gt;&gt;ChkQuestFilterUNRELEASED.Name" xml:space="preserve">
+    <value>ChkQuestFilterUNRELEASED</value>
+  </data>
+  <data name="&gt;&gt;ChkQuestFilterUNRELEASED.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ChkQuestFilterUNRELEASED.Parent" xml:space="preserve">
+    <value>GrpQuestFilters</value>
+  </data>
+  <data name="&gt;&gt;ChkQuestFilterUNRELEASED.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="ChkQuestFilterHIDDEN.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="ChkQuestFilterHIDDEN.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="ChkQuestFilterHIDDEN.Location" type="System.Drawing.Point, System.Drawing">
+    <value>41, 40</value>
+  </data>
+  <data name="ChkQuestFilterHIDDEN.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="ChkQuestFilterHIDDEN.Size" type="System.Drawing.Size, System.Drawing">
+    <value>126, 28</value>
+  </data>
+  <data name="ChkQuestFilterHIDDEN.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="ChkQuestFilterHIDDEN.Text" xml:space="preserve">
+    <value>隐藏的任务</value>
+  </data>
+  <data name="&gt;&gt;ChkQuestFilterHIDDEN.Name" xml:space="preserve">
+    <value>ChkQuestFilterHIDDEN</value>
+  </data>
+  <data name="&gt;&gt;ChkQuestFilterHIDDEN.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ChkQuestFilterHIDDEN.Parent" xml:space="preserve">
+    <value>GrpQuestFilters</value>
+  </data>
+  <data name="&gt;&gt;ChkQuestFilterHIDDEN.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="GrpQuestFilters.Location" type="System.Drawing.Point, System.Drawing">
+    <value>313, 150</value>
+  </data>
+  <data name="GrpQuestFilters.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="GrpQuestFilters.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="GrpQuestFilters.Size" type="System.Drawing.Size, System.Drawing">
-    <value>150, 130</value>
+    <value>236, 184</value>
+  </data>
+  <data name="GrpQuestFilters.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="GrpQuestFilters.Text" xml:space="preserve">
+    <value>列表过滤</value>
+  </data>
+  <data name="&gt;&gt;GrpQuestFilters.Name" xml:space="preserve">
+    <value>GrpQuestFilters</value>
+  </data>
+  <data name="&gt;&gt;GrpQuestFilters.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;GrpQuestFilters.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;GrpQuestFilters.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="BtnFinishQuest.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left</value>
+  </data>
+  <data name="BtnFinishQuest.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="BtnFinishQuest.Location" type="System.Drawing.Point, System.Drawing">
+    <value>156, 301</value>
+  </data>
+  <data name="BtnFinishQuest.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="BtnFinishQuest.Size" type="System.Drawing.Size, System.Drawing">
+    <value>141, 32</value>
+  </data>
+  <data name="BtnFinishQuest.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="BtnFinishQuest.Text" xml:space="preserve">
+    <value>完成任务</value>
   </data>
   <data name="&gt;&gt;BtnFinishQuest.Name" xml:space="preserve">
     <value>BtnFinishQuest</value>
   </data>
-  <data name="LblClearFilter.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="&gt;&gt;BtnFinishQuest.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;BtnAddQuest.Parent" xml:space="preserve">
+  <data name="&gt;&gt;BtnFinishQuest.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;BtnFinishQuest.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="ChkQuestFilterHIDDEN.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="BtnAddQuest.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Left</value>
+  </data>
+  <data name="BtnAddQuest.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="LblClearFilter.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
+  <data name="BtnAddQuest.Location" type="System.Drawing.Point, System.Drawing">
+    <value>5, 301</value>
   </data>
-  <data name="BtnFinishQuest.Location" type="System.Drawing.Point, System.Drawing">
-    <value>99, 213</value>
+  <data name="BtnAddQuest.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
-  <data name="LblClearFilter.Text" xml:space="preserve">
-    <value>X</value>
+  <data name="BtnAddQuest.Size" type="System.Drawing.Size, System.Drawing">
+    <value>141, 32</value>
+  </data>
+  <data name="BtnAddQuest.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="BtnAddQuest.Text" xml:space="preserve">
+    <value>添加任务</value>
   </data>
   <data name="&gt;&gt;BtnAddQuest.Name" xml:space="preserve">
     <value>BtnAddQuest</value>
   </data>
-  <data name="ChkAddAndFinishQuest.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Left</value>
+  <data name="&gt;&gt;BtnAddQuest.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;ChkQuestFilterHIDDEN.Name" xml:space="preserve">
-    <value>ChkQuestFilterHIDDEN</value>
-  </data>
-  <data name="ChkQuestFilterUNRELEASED.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="ChkQuestFilterUNRELEASED.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="BtnAddQuest.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 213</value>
-  </data>
-  <data name="&gt;&gt;BtnFinishQuest.Parent" xml:space="preserve">
+  <data name="&gt;&gt;BtnAddQuest.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;ChkAddAndFinishQuest.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;BtnAddQuest.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="LblQuestDescription.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left</value>
+  </data>
+  <data name="LblQuestDescription.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="LblQuestDescription.Location" type="System.Drawing.Point, System.Drawing">
+    <value>5, 4</value>
+  </data>
+  <data name="LblQuestDescription.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
+  </data>
+  <data name="LblQuestDescription.Size" type="System.Drawing.Size, System.Drawing">
+    <value>544, 141</value>
+  </data>
+  <data name="LblQuestDescription.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
   </data>
   <data name="LblQuestDescription.Text" xml:space="preserve">
     <value>添加或完成任务
 提示：许多任务需要服务端脚本支持
 因此任务可以接，可以完成，但是不一定可以做</value>
   </data>
+  <data name="&gt;&gt;LblQuestDescription.Name" xml:space="preserve">
+    <value>LblQuestDescription</value>
+  </data>
+  <data name="&gt;&gt;LblQuestDescription.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;LblQuestDescription.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;LblQuestDescription.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
   <data name="TxtQuestFilter.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
   </data>
-  <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>PageQuest</value>
+  <data name="TxtQuestFilter.Location" type="System.Drawing.Point, System.Drawing">
+    <value>558, 3</value>
+  </data>
+  <data name="TxtQuestFilter.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="TxtQuestFilter.Size" type="System.Drawing.Size, System.Drawing">
+    <value>450, 30</value>
+  </data>
+  <data name="TxtQuestFilter.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;TxtQuestFilter.Name" xml:space="preserve">
+    <value>TxtQuestFilter</value>
+  </data>
+  <data name="&gt;&gt;TxtQuestFilter.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;TxtQuestFilter.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;TxtQuestFilter.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="ListQuest.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="ListQuest.ItemHeight" type="System.Int32, mscorlib">
+    <value>24</value>
+  </data>
+  <data name="ListQuest.Location" type="System.Drawing.Point, System.Drawing">
+    <value>558, 40</value>
+  </data>
+  <data name="ListQuest.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="ListQuest.Size" type="System.Drawing.Size, System.Drawing">
+    <value>450, 292</value>
+  </data>
+  <data name="ListQuest.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;ListQuest.Name" xml:space="preserve">
+    <value>ListQuest</value>
+  </data>
+  <data name="&gt;&gt;ListQuest.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ListQuest.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ListQuest.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="LblClearFilter.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="LblClearFilter.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="LblClearFilter.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="LblClearFilter.Location" type="System.Drawing.Point, System.Drawing">
+    <value>984, 7</value>
+  </data>
+  <data name="LblClearFilter.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
+  </data>
+  <data name="LblClearFilter.Size" type="System.Drawing.Size, System.Drawing">
+    <value>22, 24</value>
+  </data>
+  <data name="LblClearFilter.TabIndex" type="System.Int32, mscorlib">
+    <value>22</value>
+  </data>
+  <data name="LblClearFilter.Text" xml:space="preserve">
+    <value>X</value>
+  </data>
+  <data name="LblClearFilter.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
   </data>
   <data name="&gt;&gt;LblClearFilter.Name" xml:space="preserve">
     <value>LblClearFilter</value>
   </data>
-  <data name="&gt;&gt;TxtQuestFilter.Parent" xml:space="preserve">
+  <data name="&gt;&gt;LblClearFilter.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;LblClearFilter.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;LblClearFilter.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;LblClearFilter.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;TxtQuestFilter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ChkQuestFilterUNRELEASED.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="LblClearFilter.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;ChkQuestFilterUNRELEASED.Parent" xml:space="preserve">
-    <value>GrpQuestFilters</value>
-  </data>
-  <data name="LblQuestDescription.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="BtnAddQuest.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="TxtQuestFilter.Location" type="System.Drawing.Point, System.Drawing">
-    <value>355, 2</value>
-  </data>
-  <data name="BtnFinishQuest.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="ChkQuestFilterHIDDEN.Text" xml:space="preserve">
-    <value>隐藏的任务</value>
-  </data>
-  <data name="ListQuest.Location" type="System.Drawing.Point, System.Drawing">
-    <value>355, 28</value>
-  </data>
-  <data name="BtnAddQuest.Size" type="System.Drawing.Size, System.Drawing">
-    <value>90, 23</value>
-  </data>
-  <data name="&gt;&gt;LblQuestDescription.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;ChkQuestFilterTEST.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="BtnFinishQuest.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+  <data name="ChkAddAndFinishQuest.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Bottom, Left</value>
   </data>
-  <data name="&gt;&gt;ListQuest.ZOrder" xml:space="preserve">
-    <value>7</value>
+  <data name="ChkAddAndFinishQuest.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="&gt;&gt;ChkQuestFilterHIDDEN.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="ChkAddAndFinishQuest.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 265</value>
   </data>
-  <data name="&gt;&gt;ListQuest.Parent" xml:space="preserve">
+  <data name="ChkAddAndFinishQuest.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="ChkAddAndFinishQuest.Size" type="System.Drawing.Size, System.Drawing">
+    <value>180, 28</value>
+  </data>
+  <data name="ChkAddAndFinishQuest.TabIndex" type="System.Int32, mscorlib">
+    <value>23</value>
+  </data>
+  <data name="ChkAddAndFinishQuest.Text" xml:space="preserve">
+    <value>选中时添加并完成</value>
+  </data>
+  <data name="&gt;&gt;ChkAddAndFinishQuest.Name" xml:space="preserve">
+    <value>ChkAddAndFinishQuest</value>
+  </data>
+  <data name="&gt;&gt;ChkAddAndFinishQuest.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ChkAddAndFinishQuest.Parent" xml:space="preserve">
     <value>$this</value>
-  </data>
-  <data name="ChkQuestFilterUNRELEASED.Text" xml:space="preserve">
-    <value>未发布的任务</value>
-  </data>
-  <data name="&gt;&gt;LblQuestDescription.Name" xml:space="preserve">
-    <value>LblQuestDescription</value>
-  </data>
-  <data name="ChkQuestFilterHIDDEN.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
   </data>
   <data name="&gt;&gt;ChkAddAndFinishQuest.ZOrder" xml:space="preserve">
     <value>0</value>
@@ -458,4 +485,16 @@
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>11, 24</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1015, 337</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>PageQuest</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>GrasscutterTools.Pages.BasePage, GrasscutterTools, Version=1.15.2.0, Culture=neutral, PublicKeyToken=de2b1c089621e923</value>
+  </data>
 </root>

--- a/Source/GrasscutterTools/Pages/PageScene.resx
+++ b/Source/GrasscutterTools/Pages/PageScene.resx
@@ -127,10 +127,13 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="RbListDungeons.Location" type="System.Drawing.Point, System.Drawing">
-    <value>287, 30</value>
+    <value>451, 42</value>
+  </data>
+  <data name="RbListDungeons.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="RbListDungeons.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 21</value>
+    <value>71, 28</value>
   </data>
   <data name="RbListDungeons.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -157,10 +160,13 @@
     <value>NoControl</value>
   </data>
   <data name="RbListScene.Location" type="System.Drawing.Point, System.Drawing">
-    <value>287, 3</value>
+    <value>451, 4</value>
+  </data>
+  <data name="RbListScene.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="RbListScene.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 21</value>
+    <value>71, 28</value>
   </data>
   <data name="RbListScene.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -184,10 +190,13 @@
     <value>Top, Left, Right</value>
   </data>
   <data name="TxtSceneFilter.Location" type="System.Drawing.Point, System.Drawing">
-    <value>343, 2</value>
+    <value>539, 3</value>
+  </data>
+  <data name="TxtSceneFilter.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="TxtSceneFilter.Size" type="System.Drawing.Size, System.Drawing">
-    <value>300, 23</value>
+    <value>469, 30</value>
   </data>
   <data name="TxtSceneFilter.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -217,10 +226,13 @@
     <value>NoControl</value>
   </data>
   <data name="ChkIncludeSceneId.Location" type="System.Drawing.Point, System.Drawing">
-    <value>87, 188</value>
+    <value>137, 267</value>
+  </data>
+  <data name="ChkIncludeSceneId.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="ChkIncludeSceneId.Size" type="System.Drawing.Size, System.Drawing">
-    <value>76, 21</value>
+    <value>109, 28</value>
   </data>
   <data name="ChkIncludeSceneId.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -250,10 +262,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblTpZ.Location" type="System.Drawing.Point, System.Drawing">
-    <value>215, 158</value>
+    <value>338, 223</value>
+  </data>
+  <data name="LblTpZ.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblTpZ.Size" type="System.Drawing.Size, System.Drawing">
-    <value>14, 17</value>
+    <value>19, 24</value>
   </data>
   <data name="LblTpZ.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -283,10 +298,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblTpY.Location" type="System.Drawing.Point, System.Drawing">
-    <value>109, 158</value>
+    <value>171, 223</value>
+  </data>
+  <data name="LblTpY.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblTpY.Size" type="System.Drawing.Size, System.Drawing">
-    <value>14, 17</value>
+    <value>20, 24</value>
   </data>
   <data name="LblTpY.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -313,10 +331,13 @@
     <value>NoControl</value>
   </data>
   <data name="BtnTeleport.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 185</value>
+    <value>9, 261</value>
+  </data>
+  <data name="BtnTeleport.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="BtnTeleport.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 25</value>
+    <value>118, 35</value>
   </data>
   <data name="BtnTeleport.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -346,10 +367,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblTpX.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 158</value>
+    <value>5, 223</value>
+  </data>
+  <data name="LblTpX.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblTpX.Size" type="System.Drawing.Size, System.Drawing">
-    <value>14, 17</value>
+    <value>19, 24</value>
   </data>
   <data name="LblTpX.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -373,10 +397,13 @@
     <value>Bottom, Left</value>
   </data>
   <data name="NUDTpZ.Location" type="System.Drawing.Point, System.Drawing">
-    <value>235, 156</value>
+    <value>369, 220</value>
+  </data>
+  <data name="NUDTpZ.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="NUDTpZ.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 23</value>
+    <value>126, 30</value>
   </data>
   <data name="NUDTpZ.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -397,10 +424,13 @@
     <value>Bottom, Left</value>
   </data>
   <data name="NUDTpY.Location" type="System.Drawing.Point, System.Drawing">
-    <value>129, 156</value>
+    <value>203, 220</value>
+  </data>
+  <data name="NUDTpY.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="NUDTpY.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 23</value>
+    <value>126, 30</value>
   </data>
   <data name="NUDTpY.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -421,10 +451,13 @@
     <value>Bottom, Left</value>
   </data>
   <data name="NUDTpX.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 156</value>
+    <value>36, 220</value>
+  </data>
+  <data name="NUDTpX.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="NUDTpX.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 23</value>
+    <value>126, 30</value>
   </data>
   <data name="NUDTpX.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -448,10 +481,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblSceneDescription.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
+    <value>5, 4</value>
+  </data>
+  <data name="LblSceneDescription.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblSceneDescription.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 17</value>
+    <value>82, 24</value>
   </data>
   <data name="LblSceneDescription.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -475,13 +511,16 @@
     <value>Top, Bottom, Left, Right</value>
   </data>
   <data name="ListScenes.ItemHeight" type="System.Int32, mscorlib">
-    <value>17</value>
+    <value>24</value>
   </data>
   <data name="ListScenes.Location" type="System.Drawing.Point, System.Drawing">
-    <value>343, 28</value>
+    <value>539, 40</value>
+  </data>
+  <data name="ListScenes.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="ListScenes.Size" type="System.Drawing.Size, System.Drawing">
-    <value>300, 208</value>
+    <value>469, 268</value>
   </data>
   <data name="ListScenes.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -508,10 +547,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblTp.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 102</value>
+    <value>5, 144</value>
+  </data>
+  <data name="LblTp.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblTp.Size" type="System.Drawing.Size, System.Drawing">
-    <value>296, 51</value>
+    <value>444, 72</value>
   </data>
   <data name="LblTp.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -541,10 +583,13 @@
     <value>NoControl</value>
   </data>
   <data name="RbListCutScene.Location" type="System.Drawing.Point, System.Drawing">
-    <value>287, 57</value>
+    <value>451, 80</value>
+  </data>
+  <data name="RbListCutScene.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="RbListCutScene.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 21</value>
+    <value>71, 28</value>
   </data>
   <data name="RbListCutScene.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -571,10 +616,13 @@
     <value>NoControl</value>
   </data>
   <data name="BtnFreezeTime.Location" type="System.Drawing.Point, System.Drawing">
-    <value>215, 184</value>
+    <value>338, 260</value>
+  </data>
+  <data name="BtnFreezeTime.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="BtnFreezeTime.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 25</value>
+    <value>157, 35</value>
   </data>
   <data name="BtnFreezeTime.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -604,10 +652,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblClearFilter.Location" type="System.Drawing.Point, System.Drawing">
-    <value>626, 5</value>
+    <value>984, 7</value>
+  </data>
+  <data name="LblClearFilter.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblClearFilter.Size" type="System.Drawing.Size, System.Drawing">
-    <value>16, 17</value>
+    <value>22, 24</value>
   </data>
   <data name="LblClearFilter.TabIndex" type="System.Int32, mscorlib">
     <value>23</value>
@@ -634,12 +685,15 @@
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>7, 17</value>
+    <value>11, 24</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1015, 337</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PageScene</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>GrasscutterTools.Pages.BasePage, GrasscutterTools, Version=1.13.0.0, Culture=neutral, PublicKeyToken=de2b1c089621e923</value>
+    <value>GrasscutterTools.Pages.BasePage, GrasscutterTools, Version=1.15.2.0, Culture=neutral, PublicKeyToken=de2b1c089621e923</value>
   </data>
 </root>

--- a/Source/GrasscutterTools/Pages/PageSceneTag.Designer.cs
+++ b/Source/GrasscutterTools/Pages/PageSceneTag.Designer.cs
@@ -56,9 +56,9 @@
             // 
             // GrpOnSelectedCheck
             // 
-            resources.ApplyResources(this.GrpOnSelectedCheck, "GrpOnSelectedCheck");
             this.GrpOnSelectedCheck.Controls.Add(this.RbOnSelectedUncheck);
             this.GrpOnSelectedCheck.Controls.Add(this.RbOnSelectedCheck);
+            resources.ApplyResources(this.GrpOnSelectedCheck, "GrpOnSelectedCheck");
             this.GrpOnSelectedCheck.Name = "GrpOnSelectedCheck";
             this.GrpOnSelectedCheck.TabStop = false;
             // 
@@ -79,9 +79,9 @@
             // 
             // GrpOnDefaultSelectedCheck
             // 
-            resources.ApplyResources(this.GrpOnDefaultSelectedCheck, "GrpOnDefaultSelectedCheck");
             this.GrpOnDefaultSelectedCheck.Controls.Add(this.RbOnDefaultSelectedCheck);
             this.GrpOnDefaultSelectedCheck.Controls.Add(this.RbOnDefaultSelectedUncheck);
+            resources.ApplyResources(this.GrpOnDefaultSelectedCheck, "GrpOnDefaultSelectedCheck");
             this.GrpOnDefaultSelectedCheck.Name = "GrpOnDefaultSelectedCheck";
             this.GrpOnDefaultSelectedCheck.TabStop = false;
             // 

--- a/Source/GrasscutterTools/Pages/PageSceneTag.resx
+++ b/Source/GrasscutterTools/Pages/PageSceneTag.resx
@@ -117,358 +117,406 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="&gt;&gt;TvSceneTags.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TreeView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="TvSceneTags.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="ChkOnSceneSelectedEnter.Size" type="System.Drawing.Size, System.Drawing">
-    <value>111, 21</value>
+  <data name="TvSceneTags.Location" type="System.Drawing.Point, System.Drawing">
+    <value>539, 4</value>
   </data>
-  <data name="&gt;&gt;LblTitle.ZOrder" xml:space="preserve">
-    <value>5</value>
+  <data name="TvSceneTags.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="TvSceneTags.Size" type="System.Drawing.Size, System.Drawing">
+    <value>469, 326</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="LblTitle.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>GrasscutterTools.Pages.BasePage, GrasscutterTools, Version=1.13.0.0, Culture=neutral, PublicKeyToken=de2b1c089621e923</value>
-  </data>
-  <data name="&gt;&gt;LblRightButtonClickTip.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;GrpOnDefaultSelectedCheck.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;RbOnDefaultSelectedUncheck.Name" xml:space="preserve">
-    <value>RbOnDefaultSelectedUncheck</value>
-  </data>
-  <data name="&gt;&gt;RbOnSelectedCheck.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;RbOnSelectedUncheck.Name" xml:space="preserve">
-    <value>RbOnSelectedUncheck</value>
-  </data>
-  <data name="&gt;&gt;TvSceneTags.ZOrder" xml:space="preserve">
+  <data name="TvSceneTags.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
+  </data>
+  <data name="&gt;&gt;TvSceneTags.Name" xml:space="preserve">
+    <value>TvSceneTags</value>
+  </data>
+  <data name="&gt;&gt;TvSceneTags.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TreeView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;TvSceneTags.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="LblTitle.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;TvSceneTags.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="RbOnSelectedUncheck.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="RbOnSelectedUncheck.Location" type="System.Drawing.Point, System.Drawing">
+    <value>20, 69</value>
+  </data>
+  <data name="RbOnSelectedUncheck.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="RbOnSelectedUncheck.Size" type="System.Drawing.Size, System.Drawing">
+    <value>107, 28</value>
+  </data>
+  <data name="RbOnSelectedUncheck.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
   <data name="RbOnSelectedUncheck.Text" xml:space="preserve">
     <value>移除标签</value>
   </data>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>7, 17</value>
-  </data>
-  <data name="&gt;&gt;BtnResetAll.Name" xml:space="preserve">
-    <value>BtnResetAll</value>
-  </data>
-  <data name="BtnResetAll.Size" type="System.Drawing.Size, System.Drawing">
-    <value>150, 25</value>
-  </data>
-  <data name="LblDefaultTagTip.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;GrpOnDefaultSelectedCheck.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;BtnUnlockAll.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;RbOnDefaultSelectedCheck.Parent" xml:space="preserve">
-    <value>GrpOnDefaultSelectedCheck</value>
-  </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="BtnResetAll.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;LblDefaultTagTip.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;BtnResetAll.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="LblRightButtonClickTip.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 17</value>
-  </data>
-  <data name="&gt;&gt;BtnUnlockAll.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="RbOnSelectedCheck.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;TvSceneTags.Name" xml:space="preserve">
-    <value>TvSceneTags</value>
-  </data>
-  <data name="GrpOnSelectedCheck.Size" type="System.Drawing.Size, System.Drawing">
-    <value>180, 80</value>
-  </data>
-  <data name="&gt;&gt;BtnUnlockAll.Name" xml:space="preserve">
-    <value>BtnUnlockAll</value>
-  </data>
-  <data name="&gt;&gt;ChkOnSceneSelectedEnter.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;RbOnDefaultSelectedCheck.Name" xml:space="preserve">
-    <value>RbOnDefaultSelectedCheck</value>
-  </data>
-  <data name="RbOnSelectedUncheck.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;RbOnDefaultSelectedCheck.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;LblTitle.Name" xml:space="preserve">
-    <value>LblTitle</value>
-  </data>
-  <data name="&gt;&gt;RbOnDefaultSelectedUncheck.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;LblDefaultTagTip.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;LblRightButtonClickTip.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="RbOnDefaultSelectedUncheck.Size" type="System.Drawing.Size, System.Drawing">
-    <value>74, 21</value>
-  </data>
-  <data name="RbOnDefaultSelectedCheck.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 22</value>
-  </data>
-  <data name="&gt;&gt;RbOnSelectedCheck.Parent" xml:space="preserve">
-    <value>GrpOnSelectedCheck</value>
-  </data>
-  <data name="LblDefaultTagTip.Text" xml:space="preserve">
-    <value>预设(Default)标签通常是锁定或者之前的状态</value>
-  </data>
-  <data name="LblRightButtonClickTip.Location" type="System.Drawing.Point, System.Drawing">
-    <value>189, 96</value>
-  </data>
-  <data name="&gt;&gt;LblTitle.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="LblRightButtonClickTip.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;GrpOnSelectedCheck.Name" xml:space="preserve">
-    <value>GrpOnSelectedCheck</value>
-  </data>
-  <data name="RbOnSelectedCheck.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="BtnUnlockAll.Text" xml:space="preserve">
-    <value>解锁全部</value>
-  </data>
-  <data name="RbOnDefaultSelectedUncheck.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 49</value>
-  </data>
-  <data name="RbOnDefaultSelectedCheck.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;LblRightButtonClickTip.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;RbOnSelectedCheck.Name" xml:space="preserve">
-    <value>RbOnSelectedCheck</value>
-  </data>
-  <data name="GrpOnSelectedCheck.Text" xml:space="preserve">
-    <value>点击标签时</value>
-  </data>
-  <data name="&gt;&gt;LblDefaultTagTip.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;GrpOnSelectedCheck.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;BtnResetAll.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="BtnResetAll.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="RbOnSelectedCheck.Size" type="System.Drawing.Size, System.Drawing">
-    <value>74, 21</value>
-  </data>
-  <data name="LblRightButtonClickTip.Text" xml:space="preserve">
-    <value>右键点击相反</value>
-  </data>
-  <data name="BtnResetAll.Text" xml:space="preserve">
-    <value>还原预设</value>
-  </data>
-  <data name="LblTitle.Text" xml:space="preserve">
-    <value>场景标签管理 (GC v1.7.2 起)</value>
-  </data>
-  <data name="RbOnSelectedUncheck.Size" type="System.Drawing.Size, System.Drawing">
-    <value>74, 21</value>
-  </data>
-  <data name="&gt;&gt;GrpOnSelectedCheck.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="RbOnDefaultSelectedCheck.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="LblTitle.Size" type="System.Drawing.Size, System.Drawing">
-    <value>162, 17</value>
-  </data>
-  <data name="&gt;&gt;ChkOnSceneSelectedEnter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="BtnResetAll.Location" type="System.Drawing.Point, System.Drawing">
-    <value>189, 34</value>
-  </data>
-  <data name="ChkOnSceneSelectedEnter.Text" xml:space="preserve">
-    <value>点击场景时进入</value>
-  </data>
-  <data name="LblDefaultTagTip.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;LblDefaultTagTip.Name" xml:space="preserve">
-    <value>LblDefaultTagTip</value>
-  </data>
-  <data name="GrpOnDefaultSelectedCheck.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 109</value>
-  </data>
-  <data name="BtnUnlockAll.Location" type="System.Drawing.Point, System.Drawing">
-    <value>189, 3</value>
-  </data>
-  <data name="BtnUnlockAll.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="GrpOnSelectedCheck.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 23</value>
-  </data>
-  <data name="&gt;&gt;GrpOnDefaultSelectedCheck.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="ChkOnSceneSelectedEnter.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;LblTitle.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="RbOnDefaultSelectedUncheck.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;ChkOnSceneSelectedEnter.Name" xml:space="preserve">
-    <value>ChkOnSceneSelectedEnter</value>
-  </data>
-  <data name="TvSceneTags.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;RbOnSelectedCheck.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="RbOnDefaultSelectedUncheck.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;BtnResetAll.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;LblRightButtonClickTip.Name" xml:space="preserve">
-    <value>LblRightButtonClickTip</value>
-  </data>
-  <data name="&gt;&gt;RbOnSelectedUncheck.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>PageSceneTag</value>
-  </data>
-  <data name="&gt;&gt;RbOnSelectedUncheck.Parent" xml:space="preserve">
-    <value>GrpOnSelectedCheck</value>
-  </data>
-  <data name="GrpOnSelectedCheck.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="GrpOnDefaultSelectedCheck.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="TvSceneTags.Size" type="System.Drawing.Size, System.Drawing">
-    <value>300, 233</value>
-  </data>
-  <data name="&gt;&gt;RbOnDefaultSelectedCheck.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="TvSceneTags.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
-  </data>
-  <data name="GrpOnDefaultSelectedCheck.Size" type="System.Drawing.Size, System.Drawing">
-    <value>180, 80</value>
-  </data>
-  <data name="&gt;&gt;GrpOnDefaultSelectedCheck.Name" xml:space="preserve">
-    <value>GrpOnDefaultSelectedCheck</value>
-  </data>
-  <data name="LblRightButtonClickTip.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="RbOnSelectedUncheck.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="BtnUnlockAll.Size" type="System.Drawing.Size, System.Drawing">
-    <value>150, 25</value>
-  </data>
-  <data name="LblDefaultTagTip.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 192</value>
-  </data>
-  <data name="RbOnSelectedUncheck.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 49</value>
-  </data>
-  <data name="LblDefaultTagTip.Size" type="System.Drawing.Size, System.Drawing">
-    <value>249, 17</value>
-  </data>
-  <data name="RbOnSelectedCheck.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 22</value>
-  </data>
-  <data name="RbOnDefaultSelectedCheck.Size" type="System.Drawing.Size, System.Drawing">
-    <value>74, 21</value>
-  </data>
-  <data name="RbOnDefaultSelectedUncheck.Text" xml:space="preserve">
-    <value>移除标签</value>
+  <data name="&gt;&gt;RbOnSelectedUncheck.Name" xml:space="preserve">
+    <value>RbOnSelectedUncheck</value>
   </data>
   <data name="&gt;&gt;RbOnSelectedUncheck.Type" xml:space="preserve">
     <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;BtnUnlockAll.Parent" xml:space="preserve">
-    <value>$this</value>
+  <data name="&gt;&gt;RbOnSelectedUncheck.Parent" xml:space="preserve">
+    <value>GrpOnSelectedCheck</value>
   </data>
-  <data name="RbOnDefaultSelectedCheck.Text" xml:space="preserve">
-    <value>添加标签</value>
+  <data name="&gt;&gt;RbOnSelectedUncheck.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
-  <data name="TvSceneTags.Location" type="System.Drawing.Point, System.Drawing">
-    <value>343, 3</value>
+  <data name="RbOnSelectedCheck.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="&gt;&gt;RbOnDefaultSelectedUncheck.Parent" xml:space="preserve">
-    <value>GrpOnDefaultSelectedCheck</value>
+  <data name="RbOnSelectedCheck.Location" type="System.Drawing.Point, System.Drawing">
+    <value>20, 31</value>
   </data>
-  <data name="&gt;&gt;RbOnDefaultSelectedUncheck.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="RbOnSelectedCheck.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
-  <data name="ChkOnSceneSelectedEnter.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 214</value>
+  <data name="RbOnSelectedCheck.Size" type="System.Drawing.Size, System.Drawing">
+    <value>107, 28</value>
   </data>
-  <data name="GrpOnDefaultSelectedCheck.Text" xml:space="preserve">
-    <value>点击(预设)标签时</value>
-  </data>
-  <data name="LblTitle.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
+  <data name="RbOnSelectedCheck.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
   </data>
   <data name="RbOnSelectedCheck.Text" xml:space="preserve">
     <value>添加标签</value>
   </data>
-  <data name="ChkOnSceneSelectedEnter.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="&gt;&gt;RbOnSelectedCheck.Name" xml:space="preserve">
+    <value>RbOnSelectedCheck</value>
+  </data>
+  <data name="&gt;&gt;RbOnSelectedCheck.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;RbOnSelectedCheck.Parent" xml:space="preserve">
+    <value>GrpOnSelectedCheck</value>
+  </data>
+  <data name="&gt;&gt;RbOnSelectedCheck.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="GrpOnSelectedCheck.Location" type="System.Drawing.Point, System.Drawing">
+    <value>5, 32</value>
+  </data>
+  <data name="GrpOnSelectedCheck.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="GrpOnSelectedCheck.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="GrpOnSelectedCheck.Size" type="System.Drawing.Size, System.Drawing">
+    <value>283, 113</value>
+  </data>
+  <data name="GrpOnSelectedCheck.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="GrpOnSelectedCheck.Text" xml:space="preserve">
+    <value>点击标签时</value>
+  </data>
+  <data name="&gt;&gt;GrpOnSelectedCheck.Name" xml:space="preserve">
+    <value>GrpOnSelectedCheck</value>
+  </data>
+  <data name="&gt;&gt;GrpOnSelectedCheck.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;GrpOnSelectedCheck.Parent" xml:space="preserve">
+    <value>$this</value>
   </data>
   <data name="&gt;&gt;GrpOnSelectedCheck.ZOrder" xml:space="preserve">
     <value>7</value>
   </data>
+  <data name="RbOnDefaultSelectedCheck.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="RbOnDefaultSelectedCheck.Location" type="System.Drawing.Point, System.Drawing">
+    <value>20, 31</value>
+  </data>
+  <data name="RbOnDefaultSelectedCheck.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="RbOnDefaultSelectedCheck.Size" type="System.Drawing.Size, System.Drawing">
+    <value>107, 28</value>
+  </data>
+  <data name="RbOnDefaultSelectedCheck.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="RbOnDefaultSelectedCheck.Text" xml:space="preserve">
+    <value>添加标签</value>
+  </data>
+  <data name="&gt;&gt;RbOnDefaultSelectedCheck.Name" xml:space="preserve">
+    <value>RbOnDefaultSelectedCheck</value>
+  </data>
+  <data name="&gt;&gt;RbOnDefaultSelectedCheck.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;RbOnDefaultSelectedCheck.Parent" xml:space="preserve">
+    <value>GrpOnDefaultSelectedCheck</value>
+  </data>
+  <data name="&gt;&gt;RbOnDefaultSelectedCheck.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="RbOnDefaultSelectedUncheck.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="RbOnDefaultSelectedUncheck.Location" type="System.Drawing.Point, System.Drawing">
+    <value>20, 69</value>
+  </data>
+  <data name="RbOnDefaultSelectedUncheck.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="RbOnDefaultSelectedUncheck.Size" type="System.Drawing.Size, System.Drawing">
+    <value>107, 28</value>
+  </data>
+  <data name="RbOnDefaultSelectedUncheck.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="RbOnDefaultSelectedUncheck.Text" xml:space="preserve">
+    <value>移除标签</value>
+  </data>
+  <data name="&gt;&gt;RbOnDefaultSelectedUncheck.Name" xml:space="preserve">
+    <value>RbOnDefaultSelectedUncheck</value>
+  </data>
+  <data name="&gt;&gt;RbOnDefaultSelectedUncheck.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;RbOnDefaultSelectedUncheck.Parent" xml:space="preserve">
+    <value>GrpOnDefaultSelectedCheck</value>
+  </data>
+  <data name="&gt;&gt;RbOnDefaultSelectedUncheck.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="GrpOnDefaultSelectedCheck.Location" type="System.Drawing.Point, System.Drawing">
+    <value>5, 154</value>
+  </data>
+  <data name="GrpOnDefaultSelectedCheck.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="GrpOnDefaultSelectedCheck.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="GrpOnDefaultSelectedCheck.Size" type="System.Drawing.Size, System.Drawing">
+    <value>283, 113</value>
+  </data>
+  <data name="GrpOnDefaultSelectedCheck.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="GrpOnDefaultSelectedCheck.Text" xml:space="preserve">
+    <value>点击(预设)标签时</value>
+  </data>
+  <data name="&gt;&gt;GrpOnDefaultSelectedCheck.Name" xml:space="preserve">
+    <value>GrpOnDefaultSelectedCheck</value>
+  </data>
+  <data name="&gt;&gt;GrpOnDefaultSelectedCheck.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;GrpOnDefaultSelectedCheck.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;GrpOnDefaultSelectedCheck.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="LblTitle.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="LblTitle.Location" type="System.Drawing.Point, System.Drawing">
+    <value>5, 4</value>
+  </data>
+  <data name="LblTitle.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
+  </data>
+  <data name="LblTitle.Size" type="System.Drawing.Size, System.Drawing">
+    <value>238, 24</value>
+  </data>
+  <data name="LblTitle.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="LblTitle.Text" xml:space="preserve">
+    <value>场景标签管理 (GC v1.7.2 起)</value>
+  </data>
+  <data name="&gt;&gt;LblTitle.Name" xml:space="preserve">
+    <value>LblTitle</value>
+  </data>
+  <data name="&gt;&gt;LblTitle.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;LblTitle.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;LblTitle.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="LblDefaultTagTip.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="LblDefaultTagTip.Location" type="System.Drawing.Point, System.Drawing">
+    <value>5, 271</value>
+  </data>
+  <data name="LblDefaultTagTip.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
+  </data>
+  <data name="LblDefaultTagTip.Size" type="System.Drawing.Size, System.Drawing">
+    <value>373, 24</value>
+  </data>
+  <data name="LblDefaultTagTip.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="LblDefaultTagTip.Text" xml:space="preserve">
+    <value>预设(Default)标签通常是锁定或者之前的状态</value>
+  </data>
+  <data name="&gt;&gt;LblDefaultTagTip.Name" xml:space="preserve">
+    <value>LblDefaultTagTip</value>
+  </data>
+  <data name="&gt;&gt;LblDefaultTagTip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;LblDefaultTagTip.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;LblDefaultTagTip.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="BtnUnlockAll.Location" type="System.Drawing.Point, System.Drawing">
+    <value>297, 4</value>
+  </data>
+  <data name="BtnUnlockAll.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="BtnUnlockAll.Size" type="System.Drawing.Size, System.Drawing">
+    <value>236, 35</value>
+  </data>
+  <data name="BtnUnlockAll.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="BtnUnlockAll.Text" xml:space="preserve">
+    <value>解锁全部</value>
+  </data>
+  <data name="&gt;&gt;BtnUnlockAll.Name" xml:space="preserve">
+    <value>BtnUnlockAll</value>
+  </data>
+  <data name="&gt;&gt;BtnUnlockAll.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;BtnUnlockAll.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;BtnUnlockAll.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="ChkOnSceneSelectedEnter.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="ChkOnSceneSelectedEnter.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 302</value>
+  </data>
+  <data name="ChkOnSceneSelectedEnter.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="ChkOnSceneSelectedEnter.Size" type="System.Drawing.Size, System.Drawing">
+    <value>162, 28</value>
+  </data>
+  <data name="ChkOnSceneSelectedEnter.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="ChkOnSceneSelectedEnter.Text" xml:space="preserve">
+    <value>点击场景时进入</value>
+  </data>
+  <data name="&gt;&gt;ChkOnSceneSelectedEnter.Name" xml:space="preserve">
+    <value>ChkOnSceneSelectedEnter</value>
+  </data>
+  <data name="&gt;&gt;ChkOnSceneSelectedEnter.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ChkOnSceneSelectedEnter.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
   <data name="&gt;&gt;ChkOnSceneSelectedEnter.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="LblRightButtonClickTip.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="LblRightButtonClickTip.Location" type="System.Drawing.Point, System.Drawing">
+    <value>297, 136</value>
+  </data>
+  <data name="LblRightButtonClickTip.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
+  </data>
+  <data name="LblRightButtonClickTip.Size" type="System.Drawing.Size, System.Drawing">
+    <value>118, 24</value>
+  </data>
+  <data name="LblRightButtonClickTip.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="LblRightButtonClickTip.Text" xml:space="preserve">
+    <value>右键点击相反</value>
+  </data>
+  <data name="&gt;&gt;LblRightButtonClickTip.Name" xml:space="preserve">
+    <value>LblRightButtonClickTip</value>
+  </data>
+  <data name="&gt;&gt;LblRightButtonClickTip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;LblRightButtonClickTip.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;LblRightButtonClickTip.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="BtnResetAll.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="BtnResetAll.Location" type="System.Drawing.Point, System.Drawing">
+    <value>297, 48</value>
+  </data>
+  <data name="BtnResetAll.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="BtnResetAll.Size" type="System.Drawing.Size, System.Drawing">
+    <value>236, 35</value>
+  </data>
+  <data name="BtnResetAll.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="BtnResetAll.Text" xml:space="preserve">
+    <value>还原预设</value>
+  </data>
+  <data name="&gt;&gt;BtnResetAll.Name" xml:space="preserve">
+    <value>BtnResetAll</value>
+  </data>
+  <data name="&gt;&gt;BtnResetAll.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;BtnResetAll.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;BtnResetAll.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>11, 24</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1015, 337</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>PageSceneTag</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>GrasscutterTools.Pages.BasePage, GrasscutterTools, Version=1.15.2.0, Culture=neutral, PublicKeyToken=de2b1c089621e923</value>
+  </data>
 </root>

--- a/Source/GrasscutterTools/Pages/PageSettings.resx
+++ b/Source/GrasscutterTools/Pages/PageSettings.resx
@@ -123,10 +123,14 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="LblPageTitle.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
+    <value>5, 4</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="LblPageTitle.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblPageTitle.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 17</value>
+    <value>82, 24</value>
   </data>
   <data name="LblPageTitle.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -147,10 +151,13 @@
     <value>10</value>
   </data>
   <data name="NUDUid.Location" type="System.Drawing.Point, System.Drawing">
-    <value>87, 39</value>
+    <value>137, 55</value>
+  </data>
+  <data name="NUDUid.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="NUDUid.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 23</value>
+    <value>157, 30</value>
   </data>
   <data name="NUDUid.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -170,15 +177,17 @@
   <data name="ChkIncludeUID.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="ChkIncludeUID.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="ChkIncludeUID.Location" type="System.Drawing.Point, System.Drawing">
-    <value>28, 40</value>
+    <value>44, 56</value>
+  </data>
+  <data name="ChkIncludeUID.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="ChkIncludeUID.Size" type="System.Drawing.Size, System.Drawing">
-    <value>65, 21</value>
+    <value>92, 28</value>
   </data>
   <data name="ChkIncludeUID.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -202,10 +211,13 @@
     <value>True</value>
   </data>
   <data name="LblIncludeUidTip.Location" type="System.Drawing.Point, System.Drawing">
-    <value>193, 41</value>
+    <value>303, 58</value>
+  </data>
+  <data name="LblIncludeUidTip.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblIncludeUidTip.Size" type="System.Drawing.Size, System.Drawing">
-    <value>104, 17</value>
+    <value>154, 24</value>
   </data>
   <data name="LblIncludeUidTip.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -232,10 +244,13 @@
     <value>Bottom, Left</value>
   </data>
   <data name="BtnResetPageList.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 202</value>
+    <value>9, 285</value>
+  </data>
+  <data name="BtnResetPageList.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="BtnResetPageList.Size" type="System.Drawing.Size, System.Drawing">
-    <value>155, 25</value>
+    <value>244, 35</value>
   </data>
   <data name="BtnResetPageList.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -259,10 +274,13 @@
     <value>Bottom, Left</value>
   </data>
   <data name="BtnMoveDown.Location" type="System.Drawing.Point, System.Drawing">
-    <value>86, 171</value>
+    <value>135, 241</value>
+  </data>
+  <data name="BtnMoveDown.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="BtnMoveDown.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 25</value>
+    <value>118, 35</value>
   </data>
   <data name="BtnMoveDown.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -286,10 +304,13 @@
     <value>Bottom, Left</value>
   </data>
   <data name="BtnMoveUp.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 171</value>
+    <value>8, 241</value>
+  </data>
+  <data name="BtnMoveUp.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="BtnMoveUp.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 25</value>
+    <value>118, 35</value>
   </data>
   <data name="BtnMoveUp.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -313,10 +334,13 @@
     <value>Top, Bottom, Left, Right</value>
   </data>
   <data name="ChkListPages.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 22</value>
+    <value>9, 31</value>
+  </data>
+  <data name="ChkListPages.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="ChkListPages.Size" type="System.Drawing.Size, System.Drawing">
-    <value>155, 148</value>
+    <value>241, 193</value>
   </data>
   <data name="ChkListPages.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -334,10 +358,16 @@
     <value>3</value>
   </data>
   <data name="GrpPageList.Location" type="System.Drawing.Point, System.Drawing">
-    <value>476, 3</value>
+    <value>748, 4</value>
+  </data>
+  <data name="GrpPageList.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
+  </data>
+  <data name="GrpPageList.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="GrpPageList.Size" type="System.Drawing.Size, System.Drawing">
-    <value>167, 233</value>
+    <value>262, 329</value>
   </data>
   <data name="GrpPageList.TabIndex" type="System.Int32, mscorlib">
     <value>100</value>
@@ -364,10 +394,13 @@
     <value>NoControl</value>
   </data>
   <data name="LblGCVersion.Location" type="System.Drawing.Point, System.Drawing">
-    <value>53, 70</value>
+    <value>83, 99</value>
+  </data>
+  <data name="LblGCVersion.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblGCVersion.Size" type="System.Drawing.Size, System.Drawing">
-    <value>25, 17</value>
+    <value>35, 24</value>
   </data>
   <data name="LblGCVersion.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -388,10 +421,13 @@
     <value>4</value>
   </data>
   <data name="CmbGcVersions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>87, 67</value>
+    <value>137, 95</value>
+  </data>
+  <data name="CmbGcVersions.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="CmbGcVersions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 25</value>
+    <value>155, 32</value>
   </data>
   <data name="CmbGcVersions.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -412,10 +448,13 @@
     <value>True</value>
   </data>
   <data name="LblGcVersionTip.Location" type="System.Drawing.Point, System.Drawing">
-    <value>193, 70</value>
+    <value>303, 99</value>
+  </data>
+  <data name="LblGcVersionTip.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblGcVersionTip.Size" type="System.Drawing.Size, System.Drawing">
-    <value>104, 17</value>
+    <value>154, 24</value>
   </data>
   <data name="LblGcVersionTip.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -442,10 +481,13 @@
     <value>NoControl</value>
   </data>
   <data name="ChkTopMost.Location" type="System.Drawing.Point, System.Drawing">
-    <value>197, 98</value>
+    <value>310, 138</value>
+  </data>
+  <data name="ChkTopMost.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="ChkTopMost.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 21</value>
+    <value>108, 28</value>
   </data>
   <data name="ChkTopMost.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -469,10 +511,13 @@
     <value>True</value>
   </data>
   <data name="LblWindowOpacity.Location" type="System.Drawing.Point, System.Drawing">
-    <value>25, 99</value>
+    <value>39, 140</value>
+  </data>
+  <data name="LblWindowOpacity.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="LblWindowOpacity.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 17</value>
+    <value>82, 24</value>
   </data>
   <data name="LblWindowOpacity.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -493,10 +538,13 @@
     <value>1</value>
   </data>
   <data name="TbWindowOpacity.Location" type="System.Drawing.Point, System.Drawing">
-    <value>87, 98</value>
+    <value>137, 138</value>
+  </data>
+  <data name="TbWindowOpacity.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 4, 5, 4</value>
   </data>
   <data name="TbWindowOpacity.Size" type="System.Drawing.Size, System.Drawing">
-    <value>104, 45</value>
+    <value>163, 69</value>
   </data>
   <data name="TbWindowOpacity.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -517,12 +565,15 @@
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>7, 17</value>
+    <value>11, 24</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1015, 337</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>PageSettings</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>GrasscutterTools.Pages.BasePage, GrasscutterTools, Version=1.13.0.0, Culture=neutral, PublicKeyToken=de2b1c089621e923</value>
+    <value>GrasscutterTools.Pages.BasePage, GrasscutterTools, Version=1.15.2.0, Culture=neutral, PublicKeyToken=de2b1c089621e923</value>
   </data>
 </root>

--- a/Source/GrasscutterTools/Program.cs
+++ b/Source/GrasscutterTools/Program.cs
@@ -71,6 +71,12 @@ namespace GrasscutterTools
             if (result != -1)
                 return result;
 
+            // 开启高DPI支持
+            if (Environment.OSVersion.Version.Major >= 6) // 至少需要Vista系统
+            {
+               HighDPIUtil.SetDpiAwareness();
+            }
+
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
 

--- a/Source/GrasscutterTools/Utils/HighDPIUtil.cs
+++ b/Source/GrasscutterTools/Utils/HighDPIUtil.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GrasscutterTools.Utils
+{
+    internal class HighDPIUtil
+    {
+        public static void SetDpiAwareness()
+        {
+            var dpiAwareness = ProcessDpiAwareness.PerMonitorDpiAware;
+            var hresult = SetProcessDpiAwareness(dpiAwareness);
+            if (hresult != 0)
+            {
+                throw new System.ComponentModel.Win32Exception(hresult);
+            }
+        }
+
+        [DllImport("shcore.dll")]
+        private static extern int SetProcessDpiAwareness(ProcessDpiAwareness value);
+
+        private enum ProcessDpiAwareness
+        {
+            DpiUnaware = 0,
+            SystemDpiAware = 1,
+            PerMonitorDpiAware = 2
+        }
+    }
+}


### PR DESCRIPTION
.NET Framework版本下的Winform有bug，添加高DPI相关代码后需要重新手动调节部分控件(ListBox、Label)尺寸才能使其正确显示。